### PR TITLE
feat: adding python-sdk as a request origin header

### DIFF
--- a/src/genai/services/request_handler.py
+++ b/src/genai/services/request_handler.py
@@ -2,6 +2,7 @@ import logging
 
 import httpx
 
+from genai._version import version
 from genai.services.connection_manager import ConnectionManager
 
 logger = logging.getLogger(__name__)
@@ -32,7 +33,7 @@ class RequestHandler:
             headers = {
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {key}",
-                "x-request-origin": "python-sdk",
+                "x-request-origin": f"python-sdk/{version}",
             }
 
             json_data = {}

--- a/src/genai/services/request_handler.py
+++ b/src/genai/services/request_handler.py
@@ -32,6 +32,7 @@ class RequestHandler:
             headers = {
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {key}",
+                "x-request-origin": "python-sdk",
             }
 
             json_data = {}


### PR DESCRIPTION
## Status
**READY**

## Description

This PR adds the following header to all requests to the watsonx.ai service:

`x-request-origin: python-sdk/version`


## Impacted Areas in Library
 - Outbound requests.

## Which issue(s) does this pull-request fix?
 - Internal Request from API Dev Team. 

## Any special notes for your reviewer?

---

## Checklist
- [x] Automated tests exist
- [x] Updated Package Requirements (if required, and with maintainers' approval)
- [x] Local unit tests performed
- [x] Documentation exists [link]()
- [x] Local pre-commit hooks performed
- [x] Desired commit message set as PR title and description set above
- [x] Link to relevant GitHub issue provided - N/A
