### PR TITLE
Adding Localserver Extension

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e ".[dev]"
-    - name: Build docs
+    - name: Build documentation
       run: |
         make -C documentation/docs html
         touch documentation/docs/build/html/.nojekyll

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,4 +48,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
-

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,40 @@
+name: Build and deploy docs
+
+on:
+    push:
+        branches: [ "main" ]
+
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build docs
+      run: |
+        make -C documentation/docs _site
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,6 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e ".[dev]"
     - name: Build docs
       run: |
         make -C documentation/docs _site

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,11 +29,14 @@ jobs:
         python -m pip install -e ".[dev]"
     - name: Build docs
       run: |
-        make -C documentation/docs _site
+        make -C documentation/docs html
+        touch documentation/docs/build/html/.nojekyll
     - name: Setup Pages
       uses: actions/configure-pages@v3
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
+      with:
+        path: "documentation/docs/build/html"
   # Deployment job
   deploy:
     environment:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,8 +1,8 @@
 name: Build and deploy docs
 
 on:
-    push:
-        branches: [ "main" ]
+  release:
+    types: [published]
 
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e ".[dev]"
-    - name: Lint with flake8
+    - name: Lint with pre-commit
       run: |
         pre-commit run --all-files
     - name: Test with pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e ".[dev]"
+    - name: Lint with flake8
+      run: |
+        pre-commit run --all-files
+    - name: Test with pytest
+      run: |
+        pytest -m unit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,15 +29,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e ".[dev]"
-    - name: Install ${{matrix.extension}} dependency
+    - name: Install Extension dependency
       if: ${{ matrix.extension != false}}
       run: python -m pip install -e ".[${{matrix.extension}}]"
     - name: Lint with pre-commit
-      run: |
-        pre-commit run --all-files
+      run: pre-commit run --all-files
     - name: Plain unit tests with pytest
       if: ${{ matrix.extension == false}}
       run: pytest -m unit
-    - name: ${{matrix.extension}} unit tests with pytest
-      if: ${{ matrix.extension != false}}
-      run: pytest -m unit or ${{matrix.extension}}
+    - if: ${{ matrix.extension != false}}
+      name: Extension tests with pytest
+      run: pytest -m 'unit or ${{matrix.extension}}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python package
+name: Python Build, Lint, Test
 
 on:
   push:
@@ -17,6 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
+        extension: ["",",langchain", ",pandas", ",huggingface"]
+        include:
+         - python-version: "3.9"
+         - python-version: "3.10"
+         - python-version: "3.11"
 
     steps:
     - uses: actions/checkout@v3
@@ -27,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e ".[dev]"
+        python -m pip install -e ".[dev${{matrix.extension}}]"
     - name: Lint with pre-commit
       run: |
         pre-commit run --all-files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        extension: [False, "langchain", "pandas", "huggingface"]
+        extension: [false, "langchain", "pandas", "huggingface"]
 
     steps:
     - uses: actions/checkout@v3
@@ -30,14 +30,14 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -e ".[dev]"
     - name: Install ${{matrix.extension}} dependency
-      if: ${{ matrix.extension != False}}
+      if: ${{ matrix.extension != false}}
       run: python -m pip install -e ".[${{matrix.extension}}]"
     - name: Lint with pre-commit
       run: |
         pre-commit run --all-files
     - name: Plain unit tests with pytest
-      if: ${{ matrix.extension == False}}
+      if: ${{ matrix.extension == false}}
       run: pytest -m unit
     - name: ${{matrix.extension}} unit tests with pytest
-      if: ${{ matrix.extension != False}}
+      if: ${{ matrix.extension != false}}
       run: pytest -m unit or ${{matrix.extension}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        include:
-          - extension: langhcain
-          - extension: pandas
-          - extension: huggingface
-
+        extension: [False, "langchain", "pandas", "huggingface"]
 
     steps:
     - uses: actions/checkout@v3
@@ -33,11 +29,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e ".[dev]"
-    - if: ${{ matrix.extension }}
-      run: python -m pip install -e ".[${{ matrix.extension }}]"
+    - name: Install ${{matrix.extension}} dependency
+      if: ${{ matrix.extension != False}}
+      run: python -m pip install -e ".[${{matrix.extension}}]"
     - name: Lint with pre-commit
       run: |
         pre-commit run --all-files
-    - name: Test with pytest
-      run: |
-        pytest -m unit
+    - name: Plain unit tests with pytest
+      if: ${{ matrix.extension == False}}
+      run: pytest -m unit
+    - name: ${{matrix.extension}} unit tests with pytest
+      if: ${{ matrix.extension != False}}
+      run: pytest -m unit or ${{matrix.extension}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        extension: ["",",langchain", ",pandas", ",huggingface"]
         include:
-         - python-version: "3.9"
-         - python-version: "3.10"
-         - python-version: "3.11"
+          - extension: langhcain
+          - extension: pandas
+          - extension: huggingface
+
 
     steps:
     - uses: actions/checkout@v3
@@ -32,7 +32,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e ".[dev${{matrix.extension}}]"
+        python -m pip install -e ".[dev]"
+    - if: ${{ matrix.extension }}
+      run: python -m pip install -e ".[${{ matrix.extension }}]"
     - name: Lint with pre-commit
       run: |
         pre-commit run --all-files

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,34 @@
+name: Upload package to pypi
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: publish
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e ".[dev]"
+    - name: Version and package
+      run: |
+        git update-index --skip-worktree src/bampy/_version.py
+        pip wheel -w dist -e . --no-deps
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         pip wheel -w dist -e . --no-deps
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@f9ed8ba9ad06d20b1ebb6002ffb93050ed9a1951
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,7 +24,6 @@ jobs:
         python -m pip install -e ".[dev]"
     - name: Version and package
       run: |
-        git update-index --skip-worktree src/bampy/_version.py
         pip wheel -w dist -e . --no-deps
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29

--- a/examples/user/adult.data.csv
+++ b/examples/user/adult.data.csv
@@ -32559,4 +32559,3 @@
 58, Private, 151910, HS-grad, 9, Widowed, Adm-clerical, Unmarried, White, Female, 0, 0, 40, United-States, <=50K
 22, Private, 201490, HS-grad, 9, Never-married, Adm-clerical, Own-child, White, Male, 0, 0, 20, United-States, <=50K
 52, Self-emp-inc, 287927, HS-grad, 9, Married-civ-spouse, Exec-managerial, Wife, White, Female, 15024, 0, 40, United-States, >50K
-

--- a/examples/user/localserver.py
+++ b/examples/user/localserver.py
@@ -1,0 +1,70 @@
+import logging
+
+# Import the ibm-generative-ai library and local server extension
+# pip install torch
+from transformers import T5ForConditionalGeneration, T5Tokenizer
+
+from genai.extensions.localserver import CustomModel, LocalLLMServer
+from genai.model import Model
+from genai.schemas import GenerateParams, GenerateResult, TokenizeResult, TokenParams
+
+logger = logging.getLogger(__name__)
+
+# Create your custom model
+
+
+class FlanT5Model(CustomModel):
+    model_id = "google/flan-t5-base"
+
+    def __init__(self):
+        logger.info("Initialising my custom flan-t5-base model")
+        self.tokenizer = T5Tokenizer.from_pretrained("google/flan-t5-base")
+        self.model = T5ForConditionalGeneration.from_pretrained("google/flan-t5-base")
+        logger.info("flan-t5-base is ready!")
+
+    def generate(self, input_text: str, params: GenerateParams) -> GenerateResult:
+        logger.info(f"Calling generate on: {input_text}")
+        input_ids = self.tokenizer(input_text, return_tensors="pt").input_ids
+        response = self.model.generate(input_ids, max_new_tokens=params.max_new_tokens)
+
+        bam_response = GenerateResult(
+            generated_text=self.tokenizer.decode(response[0]),
+            generated_token_count=response.shape[1],
+            input_token_count=input_ids.shape[1],
+            stop_reason="",
+        )
+        logger.info(f"Response to {input_text} was: {bam_response}")
+
+        return bam_response
+
+    def tokenize(self, input_text: str, params: TokenParams) -> TokenizeResult:
+        logger.info(f"Calling tokenize on: {input_text}")
+        tokenised = self.tokenizer(input_text).input_ids
+        tokens = self.tokenizer.convert_ids_to_tokens(tokenised)
+        result = TokenizeResult(token_count=len(tokens))
+        if params.return_tokens is True:
+            result.tokens = tokens
+        return result
+
+
+# Instansiate the Local Server with your model
+server = LocalLLMServer(models=[FlanT5Model])
+
+# Start the server and execute your code
+with server.run_locally():
+    print(" > Server is started")
+    # Get the credentials / connection details for the local server
+    creds = server.get_credentials()
+
+    # Instantiate parameters for text generation
+    params = GenerateParams(decoding_method="sample", max_new_tokens=10)
+
+    # Instantiate a model proxy object to send your requests
+    flan_ul2 = Model(FlanT5Model.model_id, params=params, credentials=creds)
+
+    prompts = ["Hello! How are you?", "How's the weather?"]
+    for response in flan_ul2.generate_as_completed(prompts):
+        print(f"Prompt: {response.input_text}\nResponse: {response.generated_text}")
+
+
+print(" > Server stopped, goodbye!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ibm-generative-ai"
+dynamic = ["version"]
 authors = [
   {name="Lee Martie", email="lee.martie@ibm.com"},
   {name="Ana Fucs", email="ana.fucs@ibm.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ibm-generative-ai"
-version = "0.1.14"
 authors = [
   {name="Lee Martie", email="lee.martie@ibm.com"},
   {name="Ana Fucs", email="ana.fucs@ibm.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,14 @@ huggingface = [
 pandas = [
   "pandas>=2.0.0"
 ]
+localserver = [
+  "uvicorn>=0.21.1",
+  "fastapi>=0.95.1"
+]
 
 # As new extensions are added, they should also be added
 all = [
-  "ibm-generative-ai[langchain, pandas, huggingface]"
+  "ibm-generative-ai[langchain, pandas, huggingface, localserver]"
 ]
 
 [options]
@@ -75,7 +79,8 @@ markers = [
     "integration: tests that require the GENAI API to run",
     "langchain: tests for langchain extension",
     "pandas: tests for pandas extension",
-    "huggingface: tests for huggingface extension"
+    "huggingface: tests for huggingface extension",
+    "localserver: tests for the localserver extension"
 ]
 env_files = [
     ".test.env"

--- a/src/genai/extensions/localserver/__init__.py
+++ b/src/genai/extensions/localserver/__init__.py
@@ -1,0 +1,5 @@
+# from genai.extensions.localapi.cli_plugin import BamCliPlugin
+from genai.extensions.localserver.custom_model_interface import CustomModel
+from genai.extensions.localserver.local_api_server import LocalLLMServer
+
+__all__ = ["CustomModel", "LocalLLMServer"]

--- a/src/genai/extensions/localserver/custom_model_interface.py
+++ b/src/genai/extensions/localserver/custom_model_interface.py
@@ -1,0 +1,49 @@
+from abc import ABC, abstractmethod
+
+from genai.schemas import GenerateParams, GenerateResult, TokenizeResult, TokenParams
+
+
+class CustomModel(ABC):
+    @property
+    def model_id(self):
+        """Model ID
+        This is the ID that you would use when defining the model you want to use in bampy
+
+        example: "google/flan-t5-base"
+
+        Raises:
+            NotImplementedError: If you do not implement this property.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def generate(self, input_text: str, params: GenerateParams) -> GenerateResult:
+        """Generate a response from your llm using the provided input text and parameters
+
+        Args:
+            input_text (str): The input prompt text
+            params (GenerateParams): The parameters that the user code wishes to be used
+
+        Raises:
+            NotImplementedError: If you do not implement this function.
+
+        Returns:
+            GenerateResult: The result to be sent back to the client
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def tokenize(self, input_text: str, params: TokenParams) -> TokenizeResult:
+        """Tokenize the input text with your model and return the output
+
+        Args:
+            input_text (str): The input prompt text
+            params (TokenParams): The parametersthat the user code wishes to be used
+
+        Raises:
+            NotImplementedError: If you do not implement this function.
+
+        Returns:
+            TokenizeResult: The result to be sent back to the client
+        """
+        raise NotImplementedError

--- a/src/genai/extensions/localserver/local_api_server.py
+++ b/src/genai/extensions/localserver/local_api_server.py
@@ -1,0 +1,142 @@
+import contextlib
+import datetime
+import logging
+import threading
+import time
+import uuid
+
+try:
+    import uvicorn
+    from fastapi import APIRouter, FastAPI, Request, status
+    from fastapi.responses import JSONResponse
+    from starlette.middleware.base import BaseHTTPMiddleware
+except ImportError as iex:
+    raise ImportError(f"Could not import {iex.name}: Please install ibm-bampy[localserver] extension.")
+
+
+from genai import Credentials
+from genai.extensions.localserver.custom_model_interface import CustomModel
+from genai.schemas.responses import (
+    ErrorResponse,
+    GenerateRequestBody,
+    GenerateResponse,
+    TokenizeRequestBody,
+    TokenizeResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ApiAuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, api_key: str = None, insecure: bool = False):
+        super().__init__(app)
+        self.api_key = api_key
+        self.insecure = insecure
+
+    async def dispatch(self, request: Request, call_next):
+        auth_header = request.headers["Authorization"]
+        logging.debug(f"Incoming Request: Auth: {auth_header}, Endpoint: {request.url}")
+        if self.insecure is False:
+            if str(self.api_key) not in auth_header:
+                logger.warning(f"A client used an incorrect API Key: {auth_header}")
+                response_obj = ErrorResponse(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    error="Unauthorized",
+                    message="API key not found",
+                )
+                logger.debug(response_obj.dict())
+                return JSONResponse(content=response_obj.dict(), status_code=status.HTTP_401_UNAUTHORIZED)
+        logging.debug("Calling next in chain")
+        response = await call_next(request)
+        logging.debug("Returning response")
+        return response
+
+
+class LocalLLMServer:
+    def __init__(
+        self,
+        models: list[CustomModel],
+        port: int = 8080,
+        interface: str = "0.0.0.0",
+        api_key: str = None,
+        insecure_api: bool = False,
+    ):
+        self.models = {model.model_id: model() for model in models}
+        self.port = port
+        self.interface = interface
+        self.insecure_api = insecure_api
+
+        # Set the API Key
+        if api_key is None and insecure_api is False:
+            self.api_key = uuid.uuid4()
+        elif api_key is None and insecure_api is True:
+            self.api_key = "test"
+
+        self.app = FastAPI(
+            title="IBM Generative AI Local Model Server",
+            debug=False,
+            openapi_url=False,
+            docs_url=False,
+            redoc_url=None,
+        )
+        self.router = APIRouter()
+        self.router.add_api_route("/v1/tokenize", self._route_tokenize, methods=["POST"])
+        self.router.add_api_route("/v1/generate", self._route_generate, methods=["POST"])
+        self.app.include_router(self.router)
+        self.app.add_middleware(ApiAuthMiddleware, api_key=self.api_key, insecure=insecure_api)
+
+        self.uvicorn_config = uvicorn.Config(self.app, host=interface, port=port, log_level="error", access_log=False)
+        self.uvicorn_server = uvicorn.Server(self.uvicorn_config)
+        self.endpoint = f"http://{self.interface}:{self.port}/v1"
+        logger.debug(f"{__name__}: Models: {list(self.models.keys())}, API: {self.endpoint}, Insecure: {insecure_api}")
+
+    @contextlib.contextmanager
+    def run_locally(self):
+        thread = threading.Thread(target=self.start_server)
+        thread.start()
+        try:
+            while not self.uvicorn_server.started:
+                time.sleep(1e-3)
+            yield
+        finally:
+            self.uvicorn_server.should_exit = True
+            thread.join()
+
+    def get_credentials(self):
+        return Credentials(api_key=self.api_key, api_endpoint=self.endpoint)
+
+    def start_server(self):
+        logger.debug("Starting server background process")
+
+        logger.info(f"Credentials: Endpoint: {self.endpoint} API Key: {self.api_key}")
+        logger.info(
+            f"In Python Script: credentials = Credentials(api_key={self.api_key}, api_endpoint={self.endpoint})"
+        )
+        self.uvicorn_server.run()
+
+    def stop_server(self):
+        logger.debug("Stopping server background process")
+        self.uvicorn_server.shutdown()
+
+    async def _route_tokenize(self, tokenize_request: TokenizeRequestBody):
+        logger.info(f"Tokenize called: {tokenize_request}")
+
+        results = [
+            self.models[tokenize_request.model_id].tokenize(input_text=input, params=tokenize_request.parameters)
+            for input in tokenize_request.inputs
+        ]
+
+        created_at = datetime.datetime.now().isoformat()
+        response = TokenizeResponse(model_id=tokenize_request.model_id, created_at=created_at, results=results)
+
+        return response
+
+    async def _route_generate(self, generate_request: GenerateRequestBody):
+        logger.info(f"Generate Called: Model: {generate_request.model_id}: {generate_request.inputs}")
+        results = [
+            self.models[generate_request.model_id].generate(input_text=input, params=generate_request.parameters)
+            for input in generate_request.inputs
+        ]
+        created_at = datetime.datetime.now().isoformat()
+        response = GenerateResponse(model_id=generate_request.model_id, created_at=created_at, results=results)
+        return response

--- a/src/genai/schemas/__init__.py
+++ b/src/genai/schemas/__init__.py
@@ -7,6 +7,7 @@ from genai.schemas.generate_params import (
 )
 from genai.schemas.history_params import HistoryParams
 from genai.schemas.models import ModelType
+from genai.schemas.responses import GenerateResult, TokenizeResult
 from genai.schemas.token_params import TokenParams
 
 __all__ = [
@@ -18,4 +19,6 @@ __all__ = [
     "TokenParams",
     "HistoryParams",
     "ModelType",
+    "GenerateResult",
+    "TokenizeResult",
 ]

--- a/src/genai/schemas/responses.py
+++ b/src/genai/schemas/responses.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Extra, root_validator
 
 from genai.schemas.generate_params import GenerateParams
 from genai.schemas.models import ModelType
+from genai.schemas.token_params import TokenParams
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,12 @@ class TermsOfUse(GenAiResponseModel):
     tou_accepted_at: datetime
 
 
+class GenerateRequestBody(GenAiResponseModel):
+    model_id: str
+    inputs: list[str]
+    parameters: GenerateParams
+
+
 class GeneratedToken(GenAiResponseModel):
     logprob: Optional[float]
     text: Optional[str]
@@ -81,6 +88,12 @@ class GenerateStreamResponse(GenAiResponseModel):
     generated_tokens: Optional[list[GeneratedToken]]
     input_text: Optional[str]
     seed: Optional[int]
+
+
+class TokenizeRequestBody(GenAiResponseModel):
+    model_id: str
+    inputs: list[str]
+    parameters: TokenParams
 
 
 class TokenizeResult(GenAiResponseModel):

--- a/tests/test_localserver.py
+++ b/tests/test_localserver.py
@@ -1,0 +1,69 @@
+import logging
+
+import pytest
+
+from genai.extensions.localserver import CustomModel, LocalLLMServer
+from genai.model import Model
+from genai.schemas import GenerateParams, GenerateResult, TokenizeResult, TokenParams
+
+logger = logging.getLogger(__name__)
+
+
+# Test implmentation of CustomModel class
+class ExampleModel(CustomModel):
+    model_id = "example/model"
+
+    def __init__(self):
+        logger.info("Initialising my custom model")
+
+    def generate(self, input_text: str, params: GenerateParams) -> GenerateResult:
+        logger.info(f"Calling generate on: {input_text}")
+
+        bam_response = GenerateResult(
+            generated_text=input_text,
+            generated_token_count=len(input_text.split(" ")),
+            input_token_count=len(input_text.split(" ")),
+            stop_reason="",
+        )
+        logger.info(f"Response to {input_text} was: {bam_response}")
+
+        return bam_response
+
+    def tokenize(self, input_text: str, params: TokenParams) -> TokenizeResult:
+        logger.info(f"Calling tokenize on: {input_text}")
+        tokens = input_text.split(" ")
+        result = TokenizeResult(token_count=len(tokens))
+        if params.return_tokens is True:
+            result.tokens = tokens
+        return result
+
+
+@pytest.mark.localserver
+class TestLocalServer:
+    def test_local_server(self):
+        # Instansiate the Local Server with your model
+        server = LocalLLMServer(models=[ExampleModel])
+        # Start the server and execute your code
+        with server.run_locally():
+            logger.info("Local Server Started, attempting basic generate call")
+            # Get the credentials / connection details for the local server
+            creds = server.get_credentials()
+
+            # Instantiate parameters for text generation
+            params = GenerateParams()
+
+            # Instantiate a model proxy object to send your requests
+            custom_model = Model(ExampleModel.model_id, params=params, credentials=creds)
+
+            test_prompt = "hello this is a test of a custom model in a local server"
+            responses = custom_model.generate([test_prompt])
+            assert len(responses) == 1
+            response = responses[0]
+            # Our test model simply returns the input test, so this will verify that our server is working
+            assert response.generated_text == test_prompt
+
+            token_responses = custom_model.tokenize([test_prompt])
+            assert len(token_responses) == 1
+            token_response = token_responses[0]
+            # Our test model simply returns the input test, so this will verify that our server is working
+            assert token_response.token_count == len(test_prompt.split(" "))


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Description

This PR implements a localserver extension which allows a user to host a local model on their own machine as if it was available on the watsonx.ai service. This model can then be used to tokenize and generate responses using the standard `genai` API. 

In order to use a custom model, the user must wrap their model in an instance of the `genai.extensions.localserver.CustomModel` AbstractBaseClass which exposes two main methods and a property: 

 - `model_id` (Prop) - The name of the model
 -  `generate` (Method) - The generate method which is called when the users code calls `genai.Model.generate`.
 -  `tokenize` (Method) - The tokenize method which is called when the users code calls `genai.Model.tokenize`.

A simple example has been added which shows how to do this with a model from huggingface:
`examples/user/localserver.py`


## Impacted Areas in Library
 - New Extension

## Which issue(s) does this pull-request fix?
Closes: #8 

## Any special notes for your reviewer?

---

## Checklist
- [x] Automated tests exist
- [x] Updated Package Requirements (if required, and with maintainers' approval)
- [x] Local unit tests performed
- [ ] Documentation exists [link]()
- [x] Local pre-commit hooks performed
- [x] Desired commit message set as PR title and description set above
- [x] Link to relevant GitHub issue provided
