### PR TITLE
Progress bar for async_generate method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "aiohttp>=3.8.4",
     "pyyaml>=0.2.5",
     "httpx>=0.24.0",
-    "aiolimiter>=1.0.0"
+    "aiolimiter>=1.0.0",
+    "tqdm>=4.65.0"
 ]
 requires-python = ">=3.9"
 

--- a/src/genai/model.py
+++ b/src/genai/model.py
@@ -137,6 +137,8 @@ class Model:
             ordered (bool): Whether the responses should be returned in-order.
             callback (Callable[[GenerateResult], Any]): Optional callback
                 to be called after generating result for a prompt.
+            hide_progressbar: boolean flag to hide or show a progress bar.
+                By defaul bar will be always shown.
 
         Returns:
             Generator[Union[GenerateResult, None]]: A list of results

--- a/src/genai/model.py
+++ b/src/genai/model.py
@@ -3,6 +3,8 @@ import logging
 from collections.abc import Generator
 from typing import Any, Callable, Union
 
+from tqdm import tqdm
+
 from genai.credentials import Credentials
 from genai.exceptions import GenAiException
 from genai.metadata import Metadata
@@ -121,6 +123,7 @@ class Model:
         prompts: Union[list[str], list[PromptPattern]],
         ordered: bool = False,
         callback: Callable[[GenerateResult], Any] = None,
+        hide_progressbar: bool = False,
     ) -> Generator[Union[GenerateResult, None]]:
         """The generate endpoint is the centerpiece of the GENAI alpha.
         It provides a simplified and flexible, yet powerful interface to the supported
@@ -147,7 +150,13 @@ class Model:
             with AsyncResponseGenerator(
                 self.model, prompts, self.params, self.service, ordered=ordered, callback=callback
             ) as asynchelper:
-                for response in asynchelper.generate_response():
+                for response in tqdm(
+                    asynchelper.generate_response(),
+                    total=len(prompts),
+                    desc="Progress",
+                    unit=" inputs",
+                    disable=hide_progressbar,
+                ):
                     yield response
         except GenAiException as me:
             raise me


### PR DESCRIPTION
---
## Status
**READY**

## Description

This PR improves the visual experience of `generage_async` function with a tqdm progress bar. Currently users have to create a custom progress bar as part of a callback function, or in the body of a loop that reads/prints the results of generate_async to the terminal.

## Impacted Areas in Library

Source code changes were only made in **src/genai/model.py**. I added tqdm as dependency to the `pyproject.toml` file ( @onkarbhardwaj approved doing so).

## Which issue(s) does this pull-request fix?
This was an issue (#218) in the inner-source repo of the project that was created before the open-source deployment.  Check the image below for reference.

<img width="1110" alt="Screenshot 2023-06-01 at 12 43 16 PM" src="https://github.com/IBM/ibm-generative-ai/assets/9752979/fe131b4b-4895-4210-a04c-7221f4400ebd">

## Any special notes for your reviewer?

This is a visual improvement, it can be tested with the code example below:

```
import os

from dotenv import load_dotenv

from genai.model import Credentials, Model
from genai.schemas import GenerateParams, ModelType

load_dotenv()
api_key = os.getenv("GENAI_KEY", None)

print("\n------------- Example (Async Callback Greetings)-------------\n")

params = GenerateParams(
    decoding_method="sample",
    max_new_tokens=10,
    min_new_tokens=1,
    stream=False,
    temperature=0.7,
    top_k=50,
    top_p=1,
)

creds = Credentials(api_key)
model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)

greeting = "Hello! How are you?"
lots_of_greetings = [greeting] * 100

# By default *hide_progressbar* parameter is False.
# If you want to hide the progress bar pass *hide_progressbar=True* to `generate_async`.
for result in model.generate_async(lots_of_greetings):
    pass
```

The resulting visual effect should be:

https://github.com/IBM/ibm-generative-ai/assets/9752979/b8f2d45e-d990-485b-bda6-1abb75504afa

The progress bar will always appear by default when calling `generate_async`. To hide the progress bar set *hide_progressbar* parameter to *True*. The example below shows the code update needed in the test script:

```
for result in model.generate_async(lots_of_greetings, hide_progressbar=True):
    pass
```

The expected visual effect after doing so should be:

https://github.com/IBM/ibm-generative-ai/assets/9752979/555ababe-d2ff-45e8-b832-76c6c392ca40

---
## Checklist
- [X] Automated tests exist -> Previous functionality was not broke because`test_model_async.py` passed.
- [X] Updated Package Requirements (if required, and with maintainers' approval) -> Done with approval.
- [X] Local unit tests performed -> All the existing tests passed after installing the optional dependencies.
- [X] Documentation exists [link](https://github.com/IBM/ibm-generative-ai/pull/13/commits/ab815c6e7a817b844f04552c7327fa23b4fea2b0)
- [X] Local pre-commit hooks performed
- [X] Desired commit message set as PR title and description set above
- [X] Link to relevant GitHub issue provided
