### PR TITLE
fix: resolving genai typo in some docs files

### DIFF
--- a/documentation/docs/source/rst_source/genai.exceptions.genai_exception.rst
+++ b/documentation/docs/source/rst_source/genai.exceptions.genai_exception.rst
@@ -1,7 +1,7 @@
 GENAI Exceptions
 =====================
 
-.. automodule:: genai.exceptions.bam_exception
+.. automodule:: genai.exceptions.genai_exception
    :members:
    :undoc-members:
    :show-inheritance:

--- a/documentation/docs/source/rst_source/genai.exceptions.rst
+++ b/documentation/docs/source/rst_source/genai.exceptions.rst
@@ -7,4 +7,4 @@ Submodules
 .. toctree::
    :maxdepth: 2
 
-   genai.exceptions.bam_exception
+   genai.exceptions.genai_exception


### PR DESCRIPTION
---
## Status
**READY**

## Description
Fixes some typos in the documentation referencing bam_exception, when it should be genai_exception.


## Impacted Areas in Library
 - Docs

## Which issue(s) does this pull-request fix?
  N/A

