### PR TITLE
fix: installing extensions for integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e ".[dev]"
+        python -m pip install -e ".[all]"
     - name: Run integration tests
       env:
         GENAI_API: ${{ vars.GENAI_API }}


### PR DESCRIPTION
---
## Status
**READY**

## Description

I'd not accounted for examples that require extensions to be installed when I pushed the integration test changes previously.

This PR adds the installation of the `all` group to resolve this.


## Impacted Areas in Library
 - Integration test work flow

