### PR TITLE
docs: swapped modeltype to str, connected prompts to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This is the Python SDK for IBM Foundation Models Studio to bring IBM Generative AI into Python programs and to also extend it with useful operations and types.
 
-:books:	API Documentation: [Link](https://ibm.github.io/ibm-generative-ai/)
+:books:	**API Documentation: [Link](https://ibm.github.io/ibm-generative-ai/)**
 
 *This is an early access library and requires invitation to use the technical preview of [watsonx.ai](https://watsonx.ai/). You can join the waitlist by visiting. https://www.ibm.com/products/watsonx-ai.*
 
@@ -101,11 +101,12 @@ creds = Credentials(api_key=my_api_key, api_endpoint=my_api_endpoint)
 ## <a name='Examples'></a>Examples
 
 There are a number of examples you can try in the [`examples/user`](examples/user) directory.
-Login to [workbench.res.ibm.com](https://workbench.res.ibm.com/) and get your GenAI API key. Then, create a `.env` file and assign the `GENAI_KEY` value as:
+Login to [workbench.res.ibm.com](https://workbench.res.ibm.com/) and get your GenAI API key. Then, create a `.env` file and assign the `GENAI_KEY` value as below example. [More information](#gen-ai-endpoint)
 
 
 ```ini
 GENAI_KEY=YOUR_GENAI_API_KEY
+# GENAI_API=GENAI_API_ENDPOINT << for a different endpoint
 ```
 
 ### <a name='AsyncExample'></a>Async Example
@@ -116,7 +117,7 @@ import os
 from dotenv import load_dotenv
 
 from genai.model import Credentials, Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -142,7 +143,7 @@ params = GenerateParams(
 # creds object
 creds = Credentials(api_key, api_endpoint)
 # model object
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 greeting = "Hello! How are you?"
 lots_of_greetings = [greeting] * 1000
@@ -170,7 +171,7 @@ import os
 from dotenv import load_dotenv
 
 from genai.model import Credentials, Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -196,7 +197,7 @@ params = GenerateParams(
 # creds object
 creds = Credentials(api_key, api_endpoint)
 # model object
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 greeting1 = "Hello! How are you?"
 greeting2 = "I am fine and you?"
@@ -292,7 +293,7 @@ import os
 from dotenv import load_dotenv
 import genai.extensions.langchain
 from genai.extensions.langchain import LangChainInterface
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 from genai import Credentials, Model, PromptPattern
 
 load_dotenv()
@@ -302,11 +303,11 @@ creds = Credentials(api_key, api_endpoint)
 params = GenerateParams(decoding_method="greedy")
 
 # As LangChain Model
-langchain_model = LangChainInterface(model=ModelType.FLAN_UL2, params=params, credentials=creds)
+langchain_model = LangChainInterface(model="google/flan-ul2", params=params, credentials=creds)
 print(langchain_model("Answer this question: What is life?"))
 
 # As GenAI Model
-genai_model = Model(model=ModelType.FLAN_UL2, params=params, credentials=creds)
+genai_model = Model(model="google/flan-ul2", params=params, credentials=creds)
 print(genai_model.generate(["Answer this question: What is life?"])[0].generated_text)
 
 # GenAI prompt pattern to langchain PromptTemplate and vice versa

--- a/documentation/docs/source/rst_source/examples.rst
+++ b/documentation/docs/source/rst_source/examples.rst
@@ -3,7 +3,7 @@ Examples
 
 .. note::
 
-    |:tada:| All user examples `available on Github <https://github.com/IBM/ibm-generative-ai/tree/main/examples/user>`_ !
+    All user examples `available on Github <https://github.com/IBM/ibm-generative-ai/tree/main/examples/user>`_ !
 
 .. toctree::
    :maxdepth: 4

--- a/documentation/docs/source/rst_source/genai.prompt.quickstart.annexe.rst
+++ b/documentation/docs/source/rst_source/genai.prompt.quickstart.annexe.rst
@@ -4,80 +4,33 @@ Annexe
 
 File : capital-qa.yaml
 ------------------------
-
-..  code-block:: yaml
-
-    apiVersion: v0
-    name: captial-qa
-    content: |
-        Country: Germany
-        Capital: Berlin
-        Country: USA
-        Capital: Washington
-        Country: {{country}}
-        Capital:
+.. literalinclude:: ../../../../examples/user/templates/capital-qa.yaml
+    :language: yaml
+    :caption: File is available at `capital-qa.yaml <https://github.com/IBM/ibm-generative-ai/blob/main/examples/user/templates/capital-qa.yaml>`_ on GitHub.
 
 File : synth-animal.yaml
 -------------------------
-
-.. code-block:: yaml
-
-    apiVersion: v0
-    name: synth-animal
-    content: |
-    Please generate synthetic data about {{animal}}.
-    1,{{species1}},{{location1}},{{length1}},{{dob1}}
-    2,{{species2}},{{location2}},{{length2}},{{dob2}}
-    3,{{species3}},{{location3}},{{length3}},{{dob3}}
-    4,
+.. literalinclude:: ../../../../examples/user/templates/synth-animal.yaml
+    :language: yaml
+    :caption: File is available at `synth-animal.yaml <https://github.com/IBM/ibm-generative-ai/blob/main/examples/user/templates/synth-animal.yaml>`_ on GitHub.
 
 File : penguins.csv
 ---------------------
-
-..  code-block:: text
-
-    "","species","island","bill_length_mm","bill_depth_mm","flipper_length_mm","body_mass_g","sex","year"
-    "1","Adelie","Torgersen",39.1,18.7,181,3750,"male",2007
-    "2","Adelie","Torgersen",39.5,17.4,186,3800,"female",2007
-    "3","Adelie","Torgersen",40.3,18,195,3250,"female",2007
-    "4","Adelie","Torgersen",NA,NA,NA,NA,NA,2007
-    "5","Gentoo","Biscoe",36.7,19.3,193,3450,"female",2007
-    "6","Gentoo","Biscoe",39.3,20.6,190,3650,"male",2007
-    ...
-    "341","Chinstrap","Dream",43.5,18.1,202,3400,"female",2009
-    "342","Chinstrap","Dream",49.6,18.2,193,3775,"male",2009
-    "343","Chinstrap","Dream",50.8,19,210,4100,"male",2009
-    "344","Chinstrap","Dream",50.2,18.7,198,3775,"female",2009
-
+.. literalinclude:: ../../../../examples/user/assets/penguins.csv
+    :language: text
+    :lines: 1-6,340-
+    :caption: File is available at `penguins.csv <https://github.com/IBM/ibm-generative-ai/blob/main/examples/user/assets/penguins.csv>`_ on GitHub.
 
 File : instruction.yaml
 -------------------------
-
-..  code-block:: yaml
-
-    apiVersion: v0
-    name: instruction
-    content: |
-        1. Instruction: {{instruction1}}
-        1. Input: {{input1}}
-        1. Output: {{output1}}
-
-        2. Instruction: {{instruction2}}
-        2. Input: {{input2}}
-        2. Output: {{output2}}
-
-        3. Instruction:
-
+.. literalinclude:: ../../../../examples/user/templates/instruction.yaml
+    :language: yaml
+    :lines: 2-
+    :caption: File is available at `instruction.yaml <https://github.com/IBM/ibm-generative-ai/blob/main/examples/user/templates/instruction.yaml>`_ on GitHub.
 
 File : tasks.jsonl
 -------------------------
-
-..  code-block:: json
-
-    {"id": "seed_task_0", "name": "breakfast_suggestion", "instruction": "Is there anything I can eat for a breakfast that doesn't include eggs, yet includes protein, and has roughly 700-1000 calories?", "instances": [{"input": "", "output": "Yes, you can have 1 oatmeal banana protein shake and 4 strips of bacon. The oatmeal banana protein shake may contain 1/2 cup oatmeal, 60 grams whey protein powder, 1/2 medium banana, 1tbsp flaxseed oil and 1/2 cup watter, totalling about 550 calories. The 4 strips of bacon contains about 200 calories."}], "is_classification": false},
-    {"id": "seed_task_1", "name": "antonym_relation", "instruction": "What is the relation between the given pairs?", "instances": [{"input": "Night : Day :: Right : Left", "output": "The relation between the given pairs is that they are opposites."}], "is_classification": false},
-    {"id": "seed_task_2", "name": "one_sentence_description", "instruction": "Generate a one-sentence description for each of the following people.", "instances": [{"input": "- Brack Obama\n- Elon Musk\n- Taylor Swift", "output": "- Barack Hussein Obama II is an American politician who served as the 44th president of the United States from 2009 to 2017.\n- Elon Musk is the founder, CEO, and chief engineer of SpaceX; angel investor, CEO and product architect of Tesla, Inc.; founder of The Boring Company; co-founder of Neuralink and OpenAI; president of the Musk Foundation; and owner and CEO of Twitter, Inc.\n- Taylor Alison Swift is an American singer-songwriter."}], "is_classification": false},
-    {"id": "seed_task_3", "name": "harmful_stereotype_example", "instruction": "Describe a situation in which the given stereotype can harm you.", "instances": [{"input": "\"All Asians are smart!\"", "output": "Imagine you're a small child of Asian descent. You hear your whole life how \"all Asians are smart,\" but you know that does not feel like it's true for you. You have a hard time in school. Reading is difficult. Math is impossible. Everyone around you seems to pressure you because you are supposed to be \"smart.\" Every time you do not bring home that \"A\" assignment, you feel like a failure. Like you alone missed out on the gene that makes \"all Asians smart.\"\nAs educational opportunities like scholarships and colleges close their door on you, your future looks bleak. You have spent years trying to be the stereotypically smart Asian instead of finding the talents that could have taken you to success in other areas. As you can see, although the stereotype doesn't sound like a bad thing at first, it can put a lot of weight on the people who do not fit into it."}], "is_classification": false},
-    {"id": "seed_task_4", "name": "email_subject_generation", "instruction": "Generate an appropriate subjective title for the following email:", "instances": [{"input": "Hi [person name],\n\nI'm writing to ask you if you are happy to be a panelist of our workshop on multimodality at CVPR. The workshop will be held on June 20, 2023. \n\nBest,\n[my name]", "output": "Invitition to be a panelist for CVPR 2023 workshop on Multimodality"}], "is_classification": false},
-    {"id": "seed_task_5", "name": "interview_question_answering", "instruction": "How do you answer this question in a job interview?", "instances": [{"input": "What do you think about when you are alone in a car?", "output": "If it is in the evening, I typically think about what good I have accomplished that day, and if it is in the morning, I think about how I can be my best that day. I also try to practice gratitude and live in the present moment while I'm driving to avoid distractions."}], "is_classification": false},
-    {"id": "seed_task_6", "name": "new_year's_resolutions", "instruction": "Brainstorm a list of possible New Year's resolutions.", "instances": [{"input": "", "output": "- Lose weight\n- Exercise more\n- Eat healthier\n- Quit smoking\n- Drink less alcohol\n- Spend less money\n- Save more money\n- Get out of debt\n- Take a trip\n- Volunteer more\n- Spend more time with family and friends\n- Read more\n- Start a hobby\n- Get organized\n- Simplify your life\n- Meditate or pray more\n- Get a new job\n- Move to a new city\n- Make new friends\n- Go back to school\n- Learn a new language\n- Start a business"}], "is_classification": false}
+.. literalinclude:: ../../../../examples/user/assets/seed_tasks.jsonl
+    :language: json
+    :lines: 0-6
+    :caption: File is available at `tasks.jsonl <https://github.com/IBM/ibm-generative-ai/blob/main/examples/user/assets/seed_tasks.jsonl>`_ on GitHub.

--- a/documentation/docs/source/rst_source/genai.prompt.quickstart.rst
+++ b/documentation/docs/source/rst_source/genai.prompt.quickstart.rst
@@ -28,8 +28,7 @@ Assuming local :ref:`synth-animal.yaml<File : synth-animal.yaml>` and :ref:`peng
 
 .. literalinclude:: ../../../../examples/user/prompt_from_all_csv.py
     :language: python
-    :start-at: print("\nGiven template:\n", prompt)
-    :end-at: for response in responses:
+    :lines: 42-44, 46-66
     :caption: Multiple Prompt Patterns using complete file
     :prepend: from genai.prompt_pattern import PromptPattern
               _path_to_template_file = "my_templates/synth-animal.yaml"

--- a/documentation/docs/source/rst_source/genai.prompt.quickstart.rst
+++ b/documentation/docs/source/rst_source/genai.prompt.quickstart.rst
@@ -26,40 +26,17 @@ A crucial step is to provide the mapping between the template's variables and th
 
 Assuming local :ref:`synth-animal.yaml<File : synth-animal.yaml>` and :ref:`penguins.csv<File : penguins.csv>` and files.
 
-..  code-block:: python
+.. literalinclude:: ../../../../examples/user/prompt_from_all_csv.py
+    :language: python
+    :start-at: print("\nGiven template:\n", prompt)
+    :end-at: for response in responses:
     :caption: Multiple Prompt Patterns using complete file
-
-    from genai.prompt_pattern import PromptPattern
-
-    _path_to_template_file = "my_templates/synth-animal.yaml"
-    _path_to_csv_file = "my_data/penguins.csv"
-
-    prompt = PromptPattern.from_file(_path_to_template_file)
-    print("\nGiven template:\n", prompt)
-
-    prompt.sub("animal", "penguins")
-    mapping = {
-        "species": ["species1", "species2", "species3"],
-        "island": ["location1", "location2", "location3"],
-        "flipper_length_mm": ["length1", "length2", "length3"],
-        "year": ["dob1", "dob2", "dob3"],
-    }
-
-    list_of_prompts = prompt.sub_all_from_csv(
-        csv_path=_path_to_csv_file,
-        col_to_var=mapping,
-    )
-
-    print("-----------------------")
-    print("generated prompt")
-    print(list_of_prompts)
-    print(len(list_of_prompts))
-    print("-----------------------")
-
-    responses = bloomz.generate_as_completed(list_of_prompts)
-    for response in responses:
-        # do something with response.generated_text
-
+    :prepend: from genai.prompt_pattern import PromptPattern
+              _path_to_template_file = "my_templates/synth-animal.yaml"
+              _path_to_csv_file = "my_data/penguins.csv"
+              # Create prompt pattern from the file
+              prompt = PromptPattern.from_file(_path_to_template_file)
+    :append:      # do something with response.generated_text
 
 ..  code-block:: console
     :caption: Output
@@ -134,7 +111,7 @@ Assuming local :ref:`instruction.yaml<File : instruction.yaml>` and :ref:`tasks.
     print("-----------------------")
 
 
-    responses = bloomz.generate_as_completed(list_of_prompts)
+    responses = flan_ul2.generate_as_completed(list_of_prompts)
     for response in responses:
         # do something with response.generated_text
 
@@ -225,7 +202,7 @@ Assuming local :ref:`synth-animal.yaml<File : synth-animal.yaml>` and :ref:`peng
     print(len(list_of_prompts))
     print("-----------------------")
 
-    responses = bloomz.generate_as_completed(list_of_prompts)
+    responses = flan_ul2.generate_as_completed(list_of_prompts)
     for response in responses:
         # do something with response.generated_text
 

--- a/examples/user/alice_bob_qa.py
+++ b/examples/user/alice_bob_qa.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -39,8 +39,8 @@ alice_params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-bob_model = Model(ModelType.FLAN_UL2, params=bob_params, credentials=creds)
-alice_model = Model(ModelType.FLAN_T5, params=alice_params, credentials=creds)
+bob_model = Model("google/flan-ul2", params=bob_params, credentials=creds)
+alice_model = Model("google/flan-t5-xxl", params=alice_params, credentials=creds)
 
 alice_q = "What is 1 + 1?"
 print(f"[Alice][Q] {alice_q}")

--- a/examples/user/alice_bob_talk.py
+++ b/examples/user/alice_bob_talk.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -39,8 +39,8 @@ alice_params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-bob_model = Model(ModelType.FLAN_UL2, params=bob_params, credentials=creds)
-alice_model = Model(ModelType.FLAN_T5, params=alice_params, credentials=creds)
+bob_model = Model("google/flan-ul2", params=bob_params, credentials=creds)
+alice_model = Model("google/flan-t5-xxl", params=alice_params, credentials=creds)
 
 sentence = "Hello! How are you?"
 print(f"[Alice] --> {sentence}")

--- a/examples/user/async_callback.py
+++ b/examples/user/async_callback.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -26,7 +26,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 greeting = "Hello! How are you?"
 lots_of_greetings = [greeting] * 1000

--- a/examples/user/async_greetings.py
+++ b/examples/user/async_greetings.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -26,7 +26,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 greeting = "Hello! How are you?"
 lots_of_greetings = [greeting] * 500

--- a/examples/user/async_ordered.py
+++ b/examples/user/async_ordered.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType, TokenParams
+from genai.schemas import GenerateParams, TokenParams
 
 logging.getLogger("genai").setLevel(logging.INFO)
 
@@ -24,7 +24,7 @@ generate_params = GenerateParams(decoding_method="sample", max_new_tokens=500, m
 tokenize_params = TokenParams(return_tokens=True)
 
 
-flan_ul2 = Model(ModelType.FLAN_UL2_20B, params=generate_params, credentials=creds)
+flan_ul2 = Model("google/flan-ul2", params=generate_params, credentials=creds)
 prompts = ["Explain life in one sentence:", "Write a python function to permute an array."] * 5
 print("======== Async Generate (responses need not be in order) ======== ")
 counter = 0
@@ -54,7 +54,7 @@ for response in flan_ul2.generate_async(prompts, ordered=True):
 
 
 # Instantiate a model proxy object to send your requests
-flan_ul2 = Model(ModelType.FLAN_UL2_20B, params=tokenize_params, credentials=creds)
+flan_ul2 = Model("google/flan-ul2", params=tokenize_params, credentials=creds)
 prompts = ["Explain life in one sentence:", "Write a python function to permute an array." * 5] * 5
 print("======== Async Tokenize (responses need not be in order) ======== ")
 counter = 0

--- a/examples/user/async_tokenize.py
+++ b/examples/user/async_tokenize.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import ModelType, TokenParams
+from genai.schemas import TokenParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -18,7 +18,7 @@ print("\n------------- Example (Async Greetings)-------------\n")
 params = TokenParams(return_tokens=True)
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 greeting = "Hello! How are you?"
 lots_of_greetings = [greeting] * 100

--- a/examples/user/complete_my_code.py
+++ b/examples/user/complete_my_code.py
@@ -27,7 +27,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-code_explainer = Model("salesforce/codegen-16b-mono", params=params, credentials=creds)
+code_explainer = Model("google/flan-ul2", params=params, credentials=creds)
 
 
 # pass in an actual python function to explain

--- a/examples/user/complete_my_code.py
+++ b/examples/user/complete_my_code.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -27,7 +27,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-code_explainer = Model(ModelType.CODEGEN_MONO_16B, params=params, credentials=creds)
+code_explainer = Model("salesforce/codegen-16b-mono", params=params, credentials=creds)
 
 
 # pass in an actual python function to explain

--- a/examples/user/country-capital-qa.py
+++ b/examples/user/country-capital-qa.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType, ReturnOptions
+from genai.schemas import GenerateParams, ReturnOptions
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -28,7 +28,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 prompt_path = pathlib.Path(__file__, "..", "prompts", "Country-Capital-Factual-QA").resolve()
 print(prompt_path)

--- a/examples/user/explain_my_code.py
+++ b/examples/user/explain_my_code.py
@@ -27,7 +27,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-code_explainer = Model("salesforce/codegen-16b-mono", params=params, credentials=creds)
+code_explainer = Model("google/flan-ul2", params=params, credentials=creds)
 
 
 # pass in an actual python function to explain

--- a/examples/user/explain_my_code.py
+++ b/examples/user/explain_my_code.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -27,7 +27,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-code_explainer = Model(ModelType.CODEGEN_MONO_16B, params=params, credentials=creds)
+code_explainer = Model("salesforce/codegen-16b-mono", params=params, credentials=creds)
 
 
 # pass in an actual python function to explain

--- a/examples/user/generate_with_input_text.py
+++ b/examples/user/generate_with_input_text.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -18,7 +18,7 @@ creds = Credentials(api_key, api_endpoint)  # credentials object to access GENAI
 params = GenerateParams(decoding_method="sample", max_new_tokens=10)
 
 # Instantiate a model proxy object to send your requests
-flan_ul2 = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+flan_ul2 = Model("google/flan-ul2", params=params, credentials=creds)
 
 prompts = ["Hello! How are you?", "How's the weather?"]
 for response in flan_ul2.generate_async(prompts):

--- a/examples/user/gpt_chat_bash.py
+++ b/examples/user/gpt_chat_bash.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -26,7 +26,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-chat = Model(ModelType.FLAN_UL2_20B, params=params, credentials=creds)
+chat = Model("google/flan-ul2", params=params, credentials=creds)
 
 
 prompt = "Write a bash script to split string on comma display as list"

--- a/examples/user/grid_search_params.py
+++ b/examples/user/grid_search_params.py
@@ -5,7 +5,6 @@ from dotenv import load_dotenv
 from genai.credentials import Credentials
 from genai.model import Model
 from genai.prompt_pattern import PromptPattern
-from genai.schemas import ModelType
 from genai.utils.search_space_params import grid_search_generate_params
 
 # make sure you have a .env file under genai root with
@@ -35,7 +34,7 @@ pt.sub("capital", "Madrid").sub("country", "Spain")
 generate_params_list = grid_search_generate_params(my_space_params)
 
 for params in generate_params_list:
-    model = Model(ModelType.FLAN_T5, params=params, credentials=creds)
+    model = Model("google/flan-t5-xxl", params=params, credentials=creds)
     responses = model.generate_async([str(pt)])
 
     print(f"Used params: \n{params} \n")

--- a/examples/user/grid_search_params_greeating.py
+++ b/examples/user/grid_search_params_greeating.py
@@ -4,7 +4,6 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import ModelType
 from genai.utils.search_space_params import grid_search_generate_params
 
 # make sure you have a .env file under genai root with
@@ -36,7 +35,7 @@ greeting2 = "I am fine and you?"
 generate_params_list = grid_search_generate_params(my_space_params)
 
 for params in generate_params_list:
-    model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+    model = Model("google/flan-ul2", params=params, credentials=creds)
     responses = model.generate_as_completed([greeting1, greeting2] * 4)
 
     print(f"Used params: \n{params} \n")

--- a/examples/user/jsonprompt.py
+++ b/examples/user/jsonprompt.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from genai.credentials import Credentials
 from genai.model import Model
 from genai.prompt_pattern import PromptPattern
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -30,7 +30,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 
 pt = PromptPattern.from_file(str(PATH) + os.sep + "templates" + os.sep + "instruction.yaml")

--- a/examples/user/jsonprompt_multi.py
+++ b/examples/user/jsonprompt_multi.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from genai.credentials import Credentials
 from genai.model import Model
 from genai.prompt_pattern import PromptPattern
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -30,7 +30,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 
 # load prompt pattern from file

--- a/examples/user/langchain_qa.py
+++ b/examples/user/langchain_qa.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from genai.credentials import Credentials
 from genai.extensions.langchain import LangChainInterface
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -36,8 +36,8 @@ pt2 = PromptTemplate(
 
 
 creds = Credentials(api_key, api_endpoint)
-flan = LangChainInterface(model=ModelType.FLAN_UL2, credentials=creds, params=params)
-model = LangChainInterface(model=ModelType.FLAN_UL2, credentials=creds)
+flan = LangChainInterface(model="google/flan-ul2", credentials=creds, params=params)
+model = LangChainInterface(model="google/flan-ul2", credentials=creds)
 prompt_to_flan = LLMChain(llm=flan, prompt=pt1)
 flan_to_model = LLMChain(llm=model, prompt=pt2)
 qa = SimpleSequentialChain(chains=[prompt_to_flan, flan_to_model], verbose=True)

--- a/examples/user/logprob_returns.py
+++ b/examples/user/logprob_returns.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType, ReturnOptions
+from genai.schemas import GenerateParams, ReturnOptions
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -27,7 +27,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 greeting1 = "Hello! How are you?"
 greeting2 = "I am fine and you?"

--- a/examples/user/many_greetings.py
+++ b/examples/user/many_greetings.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -26,7 +26,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 greeting1 = "Hello! How are you?"
 greeting2 = "I am fine and you?"

--- a/examples/user/prompt-raw-string.py
+++ b/examples/user/prompt-raw-string.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 from genai.credentials import Credentials
 from genai.model import Model
 from genai.prompt_pattern import PromptPattern
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -27,7 +27,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 # can live locally or at an url endpoint
 pt = PromptPattern.from_str("The capital of {{country}} is {{capital}}. The capital of Taiwan is")

--- a/examples/user/prompt_csv_random_rows.py
+++ b/examples/user/prompt_csv_random_rows.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from genai.credentials import Credentials
 from genai.model import Model
 from genai.prompt_pattern import PromptPattern
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 #
 # In this demo, the following dataset was used:
@@ -35,7 +35,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 
 pt = PromptPattern.from_file(str(PATH) + os.sep + "templates" + os.sep + "synth-animal.yaml")

--- a/examples/user/prompt_from_all_csv.py
+++ b/examples/user/prompt_from_all_csv.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from genai.credentials import Credentials
 from genai.model import Model
 from genai.prompt_pattern import PromptPattern
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 #
 # In this demo, the following dataset was used:
@@ -35,13 +35,13 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 
-pt = PromptPattern.from_file(str(PATH) + os.sep + "templates" + os.sep + "synth-animal.yaml")
-print("\nGiven template:\n", pt)
+prompt = PromptPattern.from_file(str(PATH) + os.sep + "templates" + os.sep + "synth-animal.yaml")
+print("\nGiven template:\n", prompt)
 
-pt.sub("animal", "penguins")
+prompt.sub("animal", "penguins")
 csv_path = str(PATH) + os.sep + "assets" + os.sep + "penguins.csv"
 mapping = {
     "species": ["species1", "species2", "species3"],
@@ -50,7 +50,7 @@ mapping = {
     "year": ["dob1", "dob2", "dob3"],
 }
 
-list_of_prompts = pt.sub_all_from_csv(
+list_of_prompts = prompt.sub_all_from_csv(
     csv_path=csv_path,
     col_to_var=mapping,
 )

--- a/examples/user/prompt_from_all_dataframe.py
+++ b/examples/user/prompt_from_all_dataframe.py
@@ -12,7 +12,7 @@ import genai.extensions.pandas  # noqa: F401
 from genai.credentials import Credentials
 from genai.model import Model
 from genai.prompt_pattern import PromptPattern
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 #
 # In this demo, the following dataset was used:
@@ -42,7 +42,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 pt = PromptPattern.from_file(str(PATH) + os.sep + "templates" + os.sep + "synth-animal.yaml")
 print("\nGiven template:\n", pt)

--- a/examples/user/prompt_from_dataframe.py
+++ b/examples/user/prompt_from_dataframe.py
@@ -12,7 +12,7 @@ import genai.extensions.pandas  # noqa: F401
 from genai.credentials import Credentials
 from genai.model import Model
 from genai.prompt_pattern import PromptPattern
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 #
 # In this demo, the following dataset was used:
@@ -41,7 +41,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 
 csv_path = str(PATH) + os.sep + "assets" + os.sep + "penguins.csv"

--- a/examples/user/prompt_reuse.py
+++ b/examples/user/prompt_reuse.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from genai.credentials import Credentials
 from genai.model import Model
 from genai.prompt_pattern import PromptPattern
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -29,7 +29,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 # can live locally or at an url endpoint
 pt = PromptPattern.from_file(str(PATH) + os.sep + "templates" + os.sep + "capital-qa.yaml")

--- a/examples/user/self-reflection.py
+++ b/examples/user/self-reflection.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from genai.credentials import Credentials
 from genai.model import Model
 from genai.prompt_pattern import PromptPattern
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -29,7 +29,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 # (1) Prompt
 prompt = "Is McDonald's or Burger King better?"

--- a/examples/user/streaming.py
+++ b/examples/user/streaming.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType, ReturnOptions
+from genai.schemas import GenerateParams, ReturnOptions
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -22,7 +22,7 @@ params = GenerateParams(
 )
 
 # Instantiate a model proxy object to send your requests
-flan_ul2 = Model(ModelType.FLAN_UL2_20B, params=params, credentials=creds)
+flan_ul2 = Model("google/flan-ul2", params=params, credentials=creds)
 
 prompts = [" Explain life in one sentence"]
 count = 0

--- a/examples/user/tokenize-sync.py
+++ b/examples/user/tokenize-sync.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import ModelType, TokenParams
+from genai.schemas import TokenParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -16,7 +16,7 @@ api_endpoint = os.getenv("GENAI_API", None)
 print("\n------------- Example (Tokenize)-------------\n")
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=TokenParams, credentials=creds)
+model = Model("google/flan-ul2", params=TokenParams, credentials=creds)
 
 sentence = "Hello! How are you?"
 

--- a/examples/user/tokens.py
+++ b/examples/user/tokens.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 from genai.credentials import Credentials
 from genai.model import Model
-from genai.schemas import GenerateParams, ModelType
+from genai.schemas import GenerateParams
 
 # make sure you have a .env file under genai root with
 # GENAI_KEY=<your-genai-key>
@@ -26,7 +26,7 @@ params = GenerateParams(
 )
 
 creds = Credentials(api_key, api_endpoint)
-model = Model(ModelType.FLAN_UL2, params=params, credentials=creds)
+model = Model("google/flan-ul2", params=params, credentials=creds)
 
 greeting1 = "Hello! How are you?"
 greeting2 = "I am fine and you?"

--- a/src/genai/schemas/descriptions.py
+++ b/src/genai/schemas/descriptions.py
@@ -24,17 +24,13 @@ class Descriptions:
     LENGTH_PENALTY = "It can be used to exponentially increase the likelihood of the text generation terminating once a specified number of tokens have been generated."
     MAX_NEW_TOKEN = "The maximum number of new tokens to be generated. The range is 1 to 1024, defaults to 20."
     MIN_NEW_TOKEN = "If stop sequences are given, they are ignored until minimum tokens are generated."
-    RANDOM_SEED = (
-        "Manually passed seed to initialize the randomization for experimental repeatability. The range is 1 to 9999."
-    )
+    RANDOM_SEED = "Manually passed seed to initialize the randomization for experimental repeatability. The range is 1 to 9999. Valid only with decoding_method=sample."
     STOP_SQUENCES = "Stop sequences are one or more strings which will cause the text generation to stop if/when they are produced as part of the output. Stop sequences encountered prior to the minimum number of tokens being generated will be ignored."
     STREAM = "Enables to stream partial progress as server-sent events. Defaults to false."
-    TEMPERATURE = "The value used to module the next token probabilities. The range is 0.00 to 2.00, a value set to 0.00 would make it deterministic."
+    TEMPERATURE = "The value used to module the next token probabilities. The range is 0.05 to 2.00, a value set to 0.05 would make it deterministic. Valid only with decoding_method=sample."
     TIME_LIMIT = "Time limit in milliseconds - if not completed within this time, generation will stop. The text generated so far will be returned along with the TIME_LIMIT stop reason."
-    TOP_K = (
-        "The number of highest probability vocabulary tokens to keep for top-k-filtering. The range is any value >= 1."
-    )
-    TOP_P = "If set to value < 1, only the most probable tokens with probabilities that add up to top_p or higher are kept for generation. The range is 0.00 to 1.00."
+    TOP_K = "The number of highest probability vocabulary tokens to keep for top-k-filtering. The range is any value >= 1. Valid only with decoding_method=sample."
+    TOP_P = "If set to value < 1, only the most probable tokens with probabilities that add up to top_p or higher are kept for generation. The range is 0.00 to 1.00. Valid only with decoding_method=sample."
     REPETITION_PENALTY = "The parameter for repetition penalty. 1.0 means no penalty."
     TRUNCATE_INPUT_TOKENS = "Truncate to this many input tokens. Can be used to avoid requests failing due to input being longer than configured limits. Zero means don't truncate."
 


### PR DESCRIPTION
## Status
**READY**

## Description
- Swapped `ModelType` enums to `str` on examples and README
- Connected annex files to the existing files under prompts
- Connected a prompt example to the example file
- Swapped not supported model name
- Updated API Endpoint explanation on README
- Updated param details of `GenerateParams` to explain invalid options for `greedy` decoding method

## Impacted Areas in Library

## Which issue(s) does this pull-request fix?
Contributes to: #24

## Any special notes for your reviewer?
We'll update the `prompt` section so replaced only one example to `literalinclude`
Below shows the differences:
**existing one**
<img width="827" alt="Screenshot 2023-06-28 at 11 13 00 am" src="https://github.com/IBM/ibm-generative-ai/assets/43683780/cb77b295-9908-435f-ae3f-09eb3e0570d2">

**literalinclude ver**
<img width="828" alt="Screenshot 2023-06-28 at 11 24 02 am" src="https://github.com/IBM/ibm-generative-ai/assets/43683780/57f823d2-3988-4f76-99e3-c11d3aef0e9f">

---

## Checklist
- [ ] Automated tests exist
- [ ] Updated Package Requirements (if required, and with maintainers' approval)
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local pre-commit hooks performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
