### PR TITLE
Deprecation warning for ModelType Class

### DIFF
--- a/src/genai/schemas/models.py
+++ b/src/genai/schemas/models.py
@@ -1,4 +1,17 @@
+import warnings
 from enum import Enum
+
+warnings.simplefilter("always", DeprecationWarning)
+warnings.warn(
+    """\x1b[33;20m
+The class ModelType is being deprecated.
+Please replace any reference to ModelType by its model id string equivalent.
+Example :
+  ModelType.FLAN_T5 becomes "google/flan-t5-xxl"\x1b[0m
+""",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 class ModelType(str, Enum):


### PR DESCRIPTION
---
## Status
**READY**

## Description

Added deprecation warning to the ModelType class, with simple example on how to migrate to string based model id within the warning.

## Impacted Areas in Library
`genai.schemas.models`

## Which issue(s) does this pull-request fix?
Closes #42 

## Any special notes for your reviewer?
Since ModelType is imported in the `__init__.py` file under `genai.schemas`, the warning will be thrown until we remove the ModelType file completely, even if the specific class is not imported by the user's example.

<img width="588" alt="Screenshot 2023-07-07 at 12 46 31 PM" src="https://github.com/IBM/ibm-generative-ai/assets/22043067/a97423ab-3e24-4292-84e6-9eaf50989406">
