### PR TITLE
adding escapting of backslashes for re.sub value

### DIFF
--- a/src/genai/prompt_pattern.py
+++ b/src/genai/prompt_pattern.py
@@ -201,7 +201,7 @@ class PromptPattern:
 
         pattern = re.compile(r"{{\s*" + var + r"\s*}}")
         prompt = self.dump
-        self.dump = re.sub(pattern, value, prompt)
+        self.dump = re.sub(pattern, value.replace("\\", r"\\"), prompt)
         return self
 
     def _get_idx(self, strategy, start_index, idx, max_length, random_idx_list):


### PR DESCRIPTION
---
## Status
READY

## Description
Adding escaping for back-slashes in re.sub() value.

## Impacted Areas in Library
prompt template creation

## Which issue(s) does this pull-request fix?
Closes: #83 

## Any special notes for your reviewer?

---

## Checklist
- [ ] Automated tests exist
- [ ] Updated Package Requirements (if required, and with maintainers' approval)
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local pre-commit hooks performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
