### PR TITLE
chore: update pydantic dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ readme = "README.md"
 dependencies = [
     "urllib3<2", # https://github.com/psf/requests/issues/6432
     "requests>=2.31.0",
-    "pydantic<=1.10.10",
+    "pydantic<2",
     "python-dotenv>=1.0.0",
     "aiohttp>=3.8.4",
     "pyyaml>=0.2.5",


### PR DESCRIPTION
## Status
**READY**

## Description

This PR allows its consumers to use any `pydantic` version below 2, which contains breaking changes. Currently, we have forced the consumers to use versions below `1.10.10`. Based on semantic versioning, everything on `1.x` version should not contain any breaking change.

---

## Checklist
- [ ] Automated tests exist
- [ ] Updated Package Requirements (if required, and with maintainers' approval)
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local pre-commit hooks performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
