### PR TITLE
update schema for stop_sequences generate param

### DIFF
--- a/src/genai/schemas/generate_params.py
+++ b/src/genai/schemas/generate_params.py
@@ -56,7 +56,7 @@ class GenerateParams(BaseModel):
     max_new_tokens: Optional[int] = Field(None, description=tx.MAX_NEW_TOKEN, ge=1)
     min_new_tokens: Optional[int] = Field(None, description=tx.MIN_NEW_TOKEN, ge=0)
     random_seed: Optional[int] = Field(None, description=tx.RANDOM_SEED, ge=1)
-    stop_sequences: Optional[list[str]] = Field(None, description=tx.STOP_SQUENCES, min_length=1)
+    stop_sequences: Optional[list[str]] = Field(None, description=tx.STOP_SQUENCES)
     stream: Optional[bool] = Field(None, description=tx.STREAM)
     temperature: Optional[float] = Field(None, description=tx.TEMPERATURE, ge=0.05, le=2.00)
     time_limit: Optional[int] = Field(None, description=tx.TIME_LIMIT)


### PR DESCRIPTION
---
## Status
**READY**

## Description
When added the **min_length** in the schema, it stopped working and accepting stop sequence lists like `["\n", "###", "."`] .

error: 
```pydantic.error_wrappers.ValidationError: 1 validation error for GenerateParams
stop_sequences -> 0
  ensure this value has at least 1 characters (type=value_error.any_str.min_length; limit_value=1)
```

## Impacted Areas in Library
GenerateParams schemas

## Which issue(s) does this pull-request fix?
#141 

## Checklist
- [ ] Automated tests exist
- [ ] Updated Package Requirements (if required, and with maintainers' approval)
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local pre-commit hooks performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
