### PR TITLE
fix(langchain): revert async generate

### DIFF
--- a/src/genai/extensions/langchain/llm.py
+++ b/src/genai/extensions/langchain/llm.py
@@ -139,11 +139,8 @@ class LangChainInterface(LLM, BaseModel):
             return result
 
         model = Model(model=self.model, params=params, credentials=self.credentials)
-        for response in model.generate_async(
+        for response in model.generate(
             prompts=prompts,
-            ordered=True,
-            hide_progressbar=True,
-            throw_on_error=True,
             **kwargs,
         ):
             if params.stop_sequences:

--- a/tests/extensions/test_langchain.py
+++ b/tests/extensions/test_langchain.py
@@ -34,7 +34,7 @@ class TestLangChain:
     def multi_prompts(self):
         return ["What is IBM?", "What is AI?"]
 
-    @patch("httpx.AsyncClient.post")
+    @patch("httpx.Client.post")
     def test_langchain_interface(
         self,
         mocked_post_request,
@@ -56,22 +56,15 @@ class TestLangChain:
         assert results == expected_generated_response.results[0].generated_text
 
     @pytest.mark.asyncio
-    @patch("httpx.AsyncClient.post")
+    @patch("httpx.Client.post")
     async def test_async_langchain_interface(self, mocked_post_request, credentials, params, multi_prompts):
         from genai.extensions.langchain import LangChainInterface
 
-        expected_responses = []
-        mock_responses = []
-        for prompt in multi_prompts:
-            server_response = SimpleResponse.generate(model="google/flan-ul2", inputs=[prompt], params=params)
-            expected_response = GenerateResponse(**server_response)
-            expected_responses.append(expected_response)
-
-            mock_response = MagicMock(status_code=200)
-            mock_response.json.return_value = server_response
-            mock_responses.append(mock_response)
-
-        mocked_post_request.side_effect = mock_responses
+        server_response = SimpleResponse.generate(model="google/flan-ul2", inputs=multi_prompts, params=params)
+        expected_response = GenerateResponse(**server_response)
+        mock_response = MagicMock(status_code=200)
+        mock_response.json.return_value = server_response
+        mocked_post_request.return_value = mock_response
 
         model = LangChainInterface(model="google/flan-ul2", params=params, credentials=credentials)
         observed = await model.agenerate(prompts=multi_prompts)
@@ -80,18 +73,18 @@ class TestLangChain:
         assert len(observed.generations[1]) == 1
 
         assert observed.llm_output["token_usage"]["input_token_count"] == sum(
-            c.results[0].input_token_count for c in expected_responses
+            c.input_token_count for c in expected_response.results
         )
         assert observed.llm_output["token_usage"]["generated_token_count"] == sum(
-            c.results[0].generated_token_count for c in expected_responses
+            c.generated_token_count for c in expected_response.results
         )
 
         for idx, generation_list in enumerate(observed.generations):
             assert len(generation_list) == 1
             generation = generation_list[0]
-            assert generation.text == expected_responses[idx].results[0].generated_text
+            assert generation.text == expected_response.results[idx].generated_text
 
-            expected_result = expected_responses[idx].results[0].dict()
+            expected_result = expected_response.results[idx].dict()
             for key in {"generated_token_count", "input_text", "stop_reason"}:
                 assert generation.generation_info[key] == expected_result[key]
 


### PR DESCRIPTION
## Status
**READY**

## Description

Calling `async_generate` inside our LangChain LLM crashes once it is called in parallel (`genai.exceptions.genai_exception.GenAiException: Can't have two active async_generate_clients`)

## Impacted Areas in Library
LangChain


## Code causing the error

```python
import asyncio
import os

import dotenv
import uvicorn

from genai import Credentials
from genai.extensions.langchain import LangChainInterface
from genai.schemas import GenerateParams

dotenv.load_dotenv()

api_key = os.getenv("GENAI_KEY", None)
api_endpoint = os.getenv("GENAI_API", None)


async def get_result():
    loop = asyncio.get_event_loop()

    def evaluate():
        llm = LangChainInterface(
            model="google/flan-ul2",
            credentials=Credentials(api_key, api_endpoint),
            params=GenerateParams(
                decoding_method="sample",
                max_new_tokens=10,
                min_new_tokens=1,
                stream=False,
                temperature=0.5,
                top_k=50,
                top_p=1,
            ),
        )
        result = llm.generate(
            prompts=["Tell me about IBM."],
        )
        return result

    return await loop.run_in_executor(None, evaluate)


async def app(scope, receive, send):
    result = await get_result()
    await send(
        {
            "type": "http.response.start",
            "status": 200,
        }
    )
    await send(
        {
            "type": "http.response.body",
            "body": f"{result.generations[0][0].text}".encode("utf-8"),
        }
    )


if __name__ == "__main__":
    uvicorn.run(app, port=1234, log_level="info")
```

---

## Checklist
- [ ] Automated tests exist
- [ ] Updated Package Requirements (if required, and with maintainers' approval)
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local pre-commit hooks performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
