### PR TITLE
fix(langchain): use namespace import for prompt template

### DIFF
--- a/examples/user/langchain_qa.py
+++ b/examples/user/langchain_qa.py
@@ -3,8 +3,8 @@ import os
 from dotenv import load_dotenv
 
 try:
-    from langchain import PromptTemplate
     from langchain.chains import LLMChain, SimpleSequentialChain
+    from langchain.prompts import PromptTemplate
 except ImportError:
     raise ImportError("Could not import langchain: Please install ibm-generative-ai[langchain] extension.")
 
@@ -28,7 +28,10 @@ params = GenerateParams(
     top_p=1,
 ).dict()  # Langchain uses dictionaries to pass kwargs
 
-pt1 = PromptTemplate(input_variables=["topic"], template="Generate a random question about {topic}: Question: ")
+pt1 = PromptTemplate(
+    input_variables=["topic"],
+    template="Generate a random question about {topic}: Question: ",
+)
 pt2 = PromptTemplate(
     input_variables=["question"],
     template="Answer the following question: {question}",

--- a/src/genai/extensions/langchain/prompt.py
+++ b/src/genai/extensions/langchain/prompt.py
@@ -3,7 +3,7 @@ import logging
 import re
 
 try:
-    from langchain import PromptTemplate
+    from langchain.prompts import PromptTemplate
 except ImportError:
     raise ImportError("Could not import langchain: Please install ibm-generative-ai[langchain] extension.")
 

--- a/tests/extensions/test_langchain.py
+++ b/tests/extensions/test_langchain.py
@@ -155,7 +155,7 @@ class TestLangChain:
             assert response == result.results[0]
 
     def test_prompt_translator(self):
-        from langchain import PromptTemplate
+        from langchain.prompts import PromptTemplate
 
         import genai.extensions.langchain  # noqa
         from genai.prompt_pattern import PromptPattern


### PR DESCRIPTION
---
## Status
**READY**

## Description

Fix the following warning, which occurs in a newer version of LangChain.

```
UserWarning: Importing PromptTemplate from langchain root module is no longer supported.
```


## Impacted Areas in Library
None

---

## Checklist
- [ ] Automated tests exist
- [ ] Updated Package Requirements (if required, and with maintainers' approval)
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local pre-commit hooks performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
