### PR TITLE
fix(tunes): use correct endpoint for tuning methods

### DIFF
--- a/src/genai/routers/tunes.py
+++ b/src/genai/routers/tunes.py
@@ -10,6 +10,7 @@ from genai.utils.request_utils import sanitize_params
 
 class TunesRouter:
     TUNES = "/v1/tunes"
+    TUNE_METHODS = "/v1/tune_methods"
 
     def __init__(self, service_url: str, api_key: str) -> None:
         self.service_url = service_url.rstrip("/")
@@ -74,7 +75,7 @@ class TunesRouter:
         """
         try:
             endpoint = self.service_url + TunesRouter.TUNES + "/" + tune_id
-            return RequestHandler.delete(endpoint, key=self.key, parameters=tune_id)
+            return RequestHandler.delete(endpoint, key=self.key)
         except Exception as e:
             raise GenAiException(e)
 
@@ -85,7 +86,7 @@ class TunesRouter:
             Any: json with info about the available tune methods.
         """
         try:
-            endpoint = self.service_url + "/tune_methods"
+            endpoint = self.service_url + self.TUNE_METHODS
             return RequestHandler.get(endpoint, key=self.key)
         except Exception as e:
             raise GenAiException(e)


### PR DESCRIPTION
---
## Status
**READY**

## Description

This fix sets the correct endpoint for `tune_methods` method.

## Impacted Areas in Library
TuneManager

## Which issue(s) does this pull-request fix?
Closes: #160

## Any special notes for your reviewer?

---

## Checklist
- [ ] Automated tests exist
- [ ] Updated Package Requirements (if required, and with maintainers' approval)
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local pre-commit hooks performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
