### PR TITLE
feat: add stop_sequence parameter, remove it from Langchain

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -65,7 +65,6 @@ The `LangChainInterface` class (see below) is an example of this pattern. `LangC
 
 try:
     from langchain.llms.base import LLM
-    from langchain.llms.utils import enforce_stop_tokens
 except ImportError:
     raise ImportError("Could not import langchain: Please install ibm-generative-ai[langchain] extension.")
 

--- a/src/genai/schemas/descriptions.py
+++ b/src/genai/schemas/descriptions.py
@@ -16,7 +16,7 @@ class Descriptions:
         "Include rank of each returned token. Applicable only if generated_tokens == true and/or input_tokens == true."
     )
     TOP_N_TOKENS = "Include top n candidate tokens at the position of each returned token. The maximum value permitted is 5, but more may be returned if there is a tie for nth place. Applicable only if generated_tokens == true and/or input_tokens == true."
-    STOP_SEQUENCE = "Include the concrete stop sequence which caused the generation to stop."
+    INCLUDE_STOP_SEQUENCE = "Include the concrete stop sequence which caused the generation to stop."
 
     # Params.Generate
     DECODING_METHOD = (
@@ -26,7 +26,7 @@ class Descriptions:
     MAX_NEW_TOKEN = "The maximum number of new tokens to be generated. The range is 1 to 1024, defaults to 20."
     MIN_NEW_TOKEN = "If stop sequences are given, they are ignored until minimum tokens are generated."
     RANDOM_SEED = "Manually passed seed to initialize the randomization for experimental repeatability. The range is 1 to 9999. Valid only with decoding_method=sample."
-    STOP_SQUENCES = "Stop sequences are one or more strings which will cause the text generation to stop if/when they are produced as part of the output. Stop sequences encountered prior to the minimum number of tokens being generated will be ignored."
+    STOP_SEQUENCES = "Stop sequences are one or more strings which will cause the text generation to stop if/when they are produced as part of the output. Stop sequences encountered prior to the minimum number of tokens being generated will be ignored."
     STREAM = "Enables to stream partial progress as server-sent events. Defaults to false."
     TEMPERATURE = "The value used to module the next token probabilities. The range is 0.05 to 2.00, a value set to 0.05 would make it deterministic. Valid only with decoding_method=sample."
     TIME_LIMIT = "Time limit in milliseconds - if not completed within this time, generation will stop. The text generated so far will be returned along with the TIME_LIMIT stop reason."
@@ -36,7 +36,6 @@ class Descriptions:
     REPETITION_PENALTY = "The parameter for repetition penalty. 1.0 means no penalty."
     TRUNCATE_INPUT_TOKENS = "Truncate to this many input tokens. Can be used to avoid requests failing due to input being longer than configured limits. Zero means don't truncate."
     BEAM_WIDTH = "Multiple output sequences of tokens are generated, using your decoding selection, and then the output sequence with the highest overall probability is returned. When beam search is enabled, there will be a performance penalty, and Stop sequences will not be available."  # noqa
-    INCLUDE_STOP_SEQUENCE = "Include stop sequence in the generated output."
 
     # Params.Token
     RETURN_TOKEN = "Return tokens with the response. Defaults to false."

--- a/src/genai/schemas/descriptions.py
+++ b/src/genai/schemas/descriptions.py
@@ -16,6 +16,7 @@ class Descriptions:
         "Include rank of each returned token. Applicable only if generated_tokens == true and/or input_tokens == true."
     )
     TOP_N_TOKENS = "Include top n candidate tokens at the position of each returned token. The maximum value permitted is 5, but more may be returned if there is a tie for nth place. Applicable only if generated_tokens == true and/or input_tokens == true."
+    STOP_SEQUENCE = "Include the concrete stop sequence which caused the generation to stop."
 
     # Params.Generate
     DECODING_METHOD = (
@@ -35,6 +36,7 @@ class Descriptions:
     REPETITION_PENALTY = "The parameter for repetition penalty. 1.0 means no penalty."
     TRUNCATE_INPUT_TOKENS = "Truncate to this many input tokens. Can be used to avoid requests failing due to input being longer than configured limits. Zero means don't truncate."
     BEAM_WIDTH = "Multiple output sequences of tokens are generated, using your decoding selection, and then the output sequence with the highest overall probability is returned. When beam search is enabled, there will be a performance penalty, and Stop sequences will not be available."  # noqa
+    INCLUDE_STOP_SEQUENCE = "Include stop sequence in the generated output."
 
     # Params.Token
     RETURN_TOKEN = "Return tokens with the response. Defaults to false."

--- a/src/genai/schemas/descriptions.py
+++ b/src/genai/schemas/descriptions.py
@@ -16,7 +16,6 @@ class Descriptions:
         "Include rank of each returned token. Applicable only if generated_tokens == true and/or input_tokens == true."
     )
     TOP_N_TOKENS = "Include top n candidate tokens at the position of each returned token. The maximum value permitted is 5, but more may be returned if there is a tie for nth place. Applicable only if generated_tokens == true and/or input_tokens == true."
-    INCLUDE_STOP_SEQUENCE = "Include the concrete stop sequence which caused the generation to stop."
 
     # Params.Generate
     DECODING_METHOD = (
@@ -36,6 +35,7 @@ class Descriptions:
     REPETITION_PENALTY = "The parameter for repetition penalty. 1.0 means no penalty."
     TRUNCATE_INPUT_TOKENS = "Truncate to this many input tokens. Can be used to avoid requests failing due to input being longer than configured limits. Zero means don't truncate."
     BEAM_WIDTH = "Multiple output sequences of tokens are generated, using your decoding selection, and then the output sequence with the highest overall probability is returned. When beam search is enabled, there will be a performance penalty, and Stop sequences will not be available."  # noqa
+    INCLUDE_STOP_SEQUENCE = "Include the concrete stop sequence which caused the generation to stop."
 
     # Params.Token
     RETURN_TOKEN = "Return tokens with the response. Defaults to false."

--- a/src/genai/schemas/generate_params.py
+++ b/src/genai/schemas/generate_params.py
@@ -28,6 +28,7 @@ class ReturnOptions(BaseModel):
     token_logprobs: Optional[bool] = Field(None, description=tx.TOKEN_LOGPROBS)
     token_ranks: Optional[bool] = Field(None, description=tx.TOKEN_RANKS)
     top_n_tokens: Optional[int] = Field(None, description=tx.TOP_N_TOKENS)
+    stop_tokens: Optional[str] = Field(None, description=tx.STOP_SQUENCES)
 
 
 class Return(ReturnOptions):
@@ -85,3 +86,4 @@ class GenerateParams(BaseModel):
     return_options: Optional[ReturnOptions] = Field(None, description=tx.RETURN)
     returns: Optional[Return] = Field(None, description=tx.RETURN, alias="return", deprecated=True)
     moderations: Optional[ModerationsOptions] = Field(None, description=tx.MODERATIONS)
+    include_stop_sequence: Optional[bool] = Field(None, description=tx.INCLUDE_STOP_SEQUENCE)

--- a/src/genai/schemas/generate_params.py
+++ b/src/genai/schemas/generate_params.py
@@ -28,7 +28,7 @@ class ReturnOptions(BaseModel):
     token_logprobs: Optional[bool] = Field(None, description=tx.TOKEN_LOGPROBS)
     token_ranks: Optional[bool] = Field(None, description=tx.TOKEN_RANKS)
     top_n_tokens: Optional[int] = Field(None, description=tx.TOP_N_TOKENS)
-    stop_tokens: Optional[str] = Field(None, description=tx.STOP_SQUENCES)
+    include_stop_sequence: Optional[str] = Field(None, description=tx.INCLUDE_STOP_SEQUENCE)
 
 
 class Return(ReturnOptions):
@@ -71,7 +71,7 @@ class GenerateParams(BaseModel):
     max_new_tokens: Optional[int] = Field(None, description=tx.MAX_NEW_TOKEN, ge=1)
     min_new_tokens: Optional[int] = Field(None, description=tx.MIN_NEW_TOKEN, ge=0)
     random_seed: Optional[int] = Field(None, description=tx.RANDOM_SEED, ge=1)
-    stop_sequences: Optional[list[str]] = Field(None, description=tx.STOP_SQUENCES, min_length=1)
+    stop_sequences: Optional[list[str]] = Field(None, description=tx.STOP_SEQUENCES, min_length=1)
     stream: Optional[bool] = Field(None, description=tx.STREAM)
     temperature: Optional[float] = Field(None, description=tx.TEMPERATURE, ge=0.05, le=2.00)
     time_limit: Optional[int] = Field(None, description=tx.TIME_LIMIT)
@@ -86,4 +86,3 @@ class GenerateParams(BaseModel):
     return_options: Optional[ReturnOptions] = Field(None, description=tx.RETURN)
     returns: Optional[Return] = Field(None, description=tx.RETURN, alias="return", deprecated=True)
     moderations: Optional[ModerationsOptions] = Field(None, description=tx.MODERATIONS)
-    include_stop_sequence: Optional[bool] = Field(None, description=tx.INCLUDE_STOP_SEQUENCE)

--- a/src/genai/schemas/generate_params.py
+++ b/src/genai/schemas/generate_params.py
@@ -28,7 +28,6 @@ class ReturnOptions(BaseModel):
     token_logprobs: Optional[bool] = Field(None, description=tx.TOKEN_LOGPROBS)
     token_ranks: Optional[bool] = Field(None, description=tx.TOKEN_RANKS)
     top_n_tokens: Optional[int] = Field(None, description=tx.TOP_N_TOKENS)
-    include_stop_sequence: Optional[str] = Field(None, description=tx.INCLUDE_STOP_SEQUENCE)
 
 
 class Return(ReturnOptions):
@@ -86,3 +85,4 @@ class GenerateParams(BaseModel):
     return_options: Optional[ReturnOptions] = Field(None, description=tx.RETURN)
     returns: Optional[Return] = Field(None, description=tx.RETURN, alias="return", deprecated=True)
     moderations: Optional[ModerationsOptions] = Field(None, description=tx.MODERATIONS)
+    include_stop_sequence: Optional[bool] = Field(None, description=tx.INCLUDE_STOP_SEQUENCE)

--- a/src/genai/schemas/responses.py
+++ b/src/genai/schemas/responses.py
@@ -85,6 +85,7 @@ class GenerateResult(GenAiResponseModel):
     generated_token_count: int
     input_token_count: Optional[int]
     stop_reason: str
+    stop_sequence: Optional[str]
     generated_tokens: Optional[list[GeneratedToken]]
     input_text: Optional[str]
     seed: Optional[int]
@@ -103,6 +104,7 @@ class GenerateStreamResponse(GenAiResponseModel):
     generated_token_count: Optional[int]
     input_token_count: Optional[int]
     stop_reason: Optional[str]
+    stop_sequence: Optional[str]
     generated_tokens: Optional[list[GeneratedToken]]
     input_text: Optional[str]
     seed: Optional[int]

--- a/src/genai/utils/extensions.py
+++ b/src/genai/utils/extensions.py
@@ -1,8 +1,6 @@
 # A stripped down and modified version of some definitions in
 # https://github.com/pandas-dev/pandas/blob/2.0.x/pandas/core/accessor.py
 import logging
-import re
-from typing import List
 
 logger = logging.getLogger(__name__)
 
@@ -38,11 +36,3 @@ def register_promptpattern_accessor(name: str):
     # @register_accessor("extension_name", PromptPattern)
     # class A():
     return _register_accessor(name, PromptPattern)
-
-
-def enforce_stop_tokens(text: str, stop: List[str]):
-    if not stop:
-        return text or ""
-
-    escaped_stop_sequences = [re.escape(s) for s in stop]
-    return re.split("|".join(escaped_stop_sequences), text or "", 1)[0]

--- a/tests/extensions/test_langchain.py
+++ b/tests/extensions/test_langchain.py
@@ -55,35 +55,6 @@ class TestLangChain:
         results = model(prompts[0])
         assert results == expected_generated_response.results[0].generated_text
 
-    @patch("httpx.Client.post")
-    def test_langchain_stop_sequences(
-        self,
-        mocked_post_request,
-        credentials,
-    ):
-        from genai.extensions.langchain import LangChainInterface
-
-        prompts = ["Hello..."]
-        stop_sequences = ["..."]
-
-        params = GenerateParams(stop_sequences=stop_sequences)
-        GENERATE_RESPONSE = SimpleResponse.generate(
-            model="google/flan-ul2",
-            inputs=prompts,
-            params=params,
-        )
-        expected_generated_response = GenerateResponse(**GENERATE_RESPONSE)
-        response = MagicMock(status_code=200)
-        response.json.return_value = GENERATE_RESPONSE
-        mocked_post_request.return_value = response
-
-        model = LangChainInterface(model="google/flan-ul2", params=params, credentials=credentials)
-        generated_text = model(prompts[0])
-        assert generated_text != expected_generated_response.results[0].generated_text
-        assert generated_text == "Hello"
-        for stop_sequence in stop_sequences:
-            assert stop_sequence not in generated_text
-
     @pytest.mark.asyncio
     @patch("httpx.Client.post")
     async def test_async_langchain_interface(self, mocked_post_request, credentials, params, multi_prompts):


### PR DESCRIPTION
---
## Status
**READY**

## Description

Add new generate input parameter `stop_sequence` and return options parameter `include_stop_sequence`.
Remove the `enforce_stop_tokens` function from LangChain as we want consistent behaviour across the whole project.

## Impacted Areas in Library
Generate, LangChain

## Which issue(s) does this pull-request fix?
Closes: #183

---

## Checklist
- [ ] Automated tests exist
- [ ] Updated Package Requirements (if required, and with maintainers' approval)
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local pre-commit hooks performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
