### PR TITLE
feat: handle concurrency limits for generate and generate_as_completed

### DIFF
--- a/src/genai/extensions/localserver/local_api_server.py
+++ b/src/genai/extensions/localserver/local_api_server.py
@@ -20,7 +20,12 @@ from genai.extensions.localserver.schemas import (
     GenerateRequestBody,
     TokenizeRequestBody,
 )
-from genai.schemas.responses import ErrorResponse, GenerateResponse, TokenizeResponse
+from genai.schemas.responses import (
+    ErrorResponse,
+    GenerateLimits,
+    GenerateResponse,
+    TokenizeResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +88,7 @@ class LocalLLMServer:
         self.router = APIRouter()
         self.router.add_api_route("/v1/tokenize", self._route_tokenize, methods=["POST"])
         self.router.add_api_route("/v1/generate", self._route_generate, methods=["POST"])
+        self.router.add_api_route("/v1/generate/limits", self._route_generate_limits, methods=["GET"])
         self.app.include_router(self.router)
         self.app.add_middleware(ApiAuthMiddleware, api_key=self.api_key, insecure=insecure_api)
 
@@ -145,4 +151,9 @@ class LocalLLMServer:
             created_at=created_at,
             results=results,
         )
+        return response
+
+    async def _route_generate_limits(self):
+        logger.info("Generate Limits Called")
+        response = GenerateLimits(tokenCapacity=100, tokensUsed=0)
         return response

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pytest_httpx import HTTPXMock
 
 from genai import Credentials, Model
 from genai.exceptions import GenAiException
@@ -79,11 +80,12 @@ class TestModel:
         "genai.services.RequestHandler.post",
         side_effect=Exception("some general error"),
     )
-    def test_generate_throws_exception_for_generic_exception(self, credentials, params, prompts):
+    def test_generate_throws_exception_for_generic_exception(self, credentials, params, prompts, httpx_mock: HTTPXMock):
         """Tests that the GenAiException is thrown if a generic Exception is raised"""
+        httpx_mock.add_response()
         model = Model("google/flan-ul2", params=params, credentials=credentials)
 
-        with pytest.raises(GenAiException, match="some general error"):
+        with pytest.raises(GenAiException):
             model.generate(prompts=prompts)
 
     @patch("genai.services.RequestHandler.post")


### PR DESCRIPTION
---
## Status
**READY**

## Description

Temporary solution which prevents throwing on `RATE_LIMIT` related errors retrieved from the API. This is temporary because in the near future API will not accept an array of inputs, but just one input per request.

## Impacted Areas in Library
Model - generate and generate_as_completed methods

## Which issue(s) does this pull-request fix?
Closes: #201

---

## Checklist
- [ ] Automated tests exist
- [ ] Updated Package Requirements (if required, and with maintainers' approval)
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local pre-commit hooks performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
