### PR TITLE
chore: change logger level for non explicitly defined properties

### DIFF
--- a/src/genai/schemas/responses.py
+++ b/src/genai/schemas/responses.py
@@ -34,7 +34,7 @@ def alert_extra_fields_validator(cls, values) -> dict:
     extra_fields = values.keys() - cls.__fields__.keys()
 
     if extra_fields:
-        logger.warning(
+        logger.debug(
             f"Extra fields missing from {cls.__name__}. Add Optional[Type] typing for these fields: {extra_fields}"
         )
 

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -55,7 +55,7 @@ class TestSchemas:
             caplog (Generator[LogCaptureFixture, None, None]): The Logging capture during the test
         """
         self.caplog = caplog
-        self.caplog.set_level(logging.WARNING)
+        self.caplog.set_level(logging.DEBUG)
 
         # Test Generate Result
         generate_example = SimpleResponse.generate(model=self.model, inputs=self.inputs)


### PR DESCRIPTION
---
## Status
**READY**

## Description

When there is a new (yet unknown) field from the API, it triggers a warning in the SDK. 
This message is not fatal and is not intended for the end user.