### PR TITLE
feat: switch to custom retry http transporter instead of manual retries

### DIFF
--- a/src/genai/services/connection_manager.py
+++ b/src/genai/services/connection_manager.py
@@ -5,13 +5,13 @@ from genai.exceptions import GenAiException
 __all__ = ["ConnectionManager"]
 
 from genai.utils.http_provider import HttpProvider
-from genai.utils.http_utils import AsyncRateLimitTransport
+from genai.utils.http_utils import AsyncRateLimitTransport, AsyncRetryTransport
 
 
 class ConnectionManager:
-    MAX_RETRIES_GENERATE = 3
+    MAX_RETRIES_GENERATE = 5
     TIMEOUT_GENERATE = 600
-    MAX_RETRIES_TOKENIZE = 3
+    MAX_RETRIES_TOKENIZE = 5
     MAX_REQ_PER_SECOND_TOKENIZE = 10
     TIMEOUT = 600
 
@@ -25,8 +25,8 @@ class ConnectionManager:
             raise GenAiException(ValueError("Can't have two active async_generate_clients"))
 
         ConnectionManager.async_generate_client = HttpProvider.get_async_client(
-            transport=HttpProvider.get_async_transport(
-                retries=ConnectionManager.MAX_RETRIES_GENERATE,
+            transport=AsyncRetryTransport(
+                retries=ConnectionManager.MAX_RETRIES_GENERATE, **HttpProvider.default_http_transport_options
             ),
             timeout=ConnectionManager.TIMEOUT_GENERATE,
         )

--- a/src/genai/services/request_handler.py
+++ b/src/genai/services/request_handler.py
@@ -1,8 +1,6 @@
-import asyncio
 import logging
 from typing import Optional
 
-import httpx
 from httpx import Response
 from httpx_sse import SSEError, connect_sse
 
@@ -160,17 +158,7 @@ class RequestHandler:
             parameters=parameters,
             options=options,
         )
-        response = None
-        for attempt in range(0, ConnectionManager.MAX_RETRIES_GENERATE):
-            response = await ConnectionManager.async_generate_client.post(endpoint, headers=headers, json=json_data)
-            if response.status_code in [
-                httpx.codes.SERVICE_UNAVAILABLE,
-                httpx.codes.TOO_MANY_REQUESTS,
-            ]:
-                await asyncio.sleep(2 ** (attempt + 1))
-            else:
-                break
-        return response
+        return await ConnectionManager.async_generate_client.post(endpoint, headers=headers, json=json_data)
 
     @staticmethod
     async def async_tokenize(


### PR DESCRIPTION
---
## Status
**READY**

## Description

Switch to custom retry http transporter instead of manual retries. Also, increase retry limits.

## Impacted Areas in Library
Generate/Tokenize Async

## Which issue(s) does this pull-request fix?
Backward contribute to: #147

## Any special notes for your reviewer?

---

## Checklist
- [ ] Automated tests exist
- [ ] Updated Package Requirements (if required, and with maintainers' approval)
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local pre-commit hooks performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
