### PR TITLE
fix(files): correct type and add test example

### DIFF
--- a/examples/user/files.py
+++ b/examples/user/files.py
@@ -1,0 +1,37 @@
+import os
+import tempfile
+
+from dotenv import load_dotenv
+
+from genai.credentials import Credentials
+from genai.schemas import FileListParams
+from genai.services import FileManager
+
+# make sure you have a .env file under genai root with
+# GENAI_KEY=<your-genai-key>
+# GENAI_API=<genai-api-endpoint>
+load_dotenv()
+api_key = os.getenv("GENAI_KEY", None)
+api_endpoint = os.getenv("GENAI_API", None)
+credentials = Credentials(api_key, api_endpoint)
+
+print("\n------------- Example (Working with files)-------------\n")
+
+with tempfile.NamedTemporaryFile(delete=True, suffix=".json") as tmp:
+    content = '{"input": "<input>", "output": "<ideal output>"}'
+    tmp.write(content.encode())
+    tmp.seek(0)
+
+    filename = os.path.basename(tmp.name)
+
+    upload_result = FileManager.upload_file(file_path=tmp.name, purpose="tune", credentials=credentials)
+    try:
+        files = FileManager.list_files(credentials=credentials, params=FileListParams(search=filename))
+        assert files.totalCount == 1
+        assert len(files.results) == 1
+        metadata = FileManager.file_metadata(upload_result.id, credentials=credentials)
+        assert metadata.file_name == filename
+        assert metadata.bytes > 0
+        assert content == FileManager.read_file(upload_result.id, credentials=credentials)
+    finally:
+        FileManager.delete_file(upload_result.id, credentials=credentials)

--- a/src/genai/routers/files.py
+++ b/src/genai/routers/files.py
@@ -1,3 +1,5 @@
+from httpx import Response
+
 from genai.schemas.files_params import FileListParams, MultipartFormData
 from genai.services.request_handler import RequestHandler
 from genai.utils.errors import to_genai_error
@@ -11,7 +13,7 @@ class FilesRouter:
         self.service_url = service_url.rstrip("/")
         self.key = api_key
 
-    def list_files(self, params: FileListParams = None):
+    def list_files(self, params: FileListParams = None) -> Response:
         """List all files on the server.
 
         Args:
@@ -27,7 +29,7 @@ class FilesRouter:
         except Exception as e:
             raise to_genai_error(e)
 
-    def get_file_metadata(self, file_id: str):
+    def get_file_metadata(self, file_id: str) -> Response:
         """Get the file metadata from the server.
 
         Args:
@@ -42,7 +44,7 @@ class FilesRouter:
         except Exception as e:
             raise to_genai_error(e)
 
-    def read_file(self, file_id: str):
+    def read_file(self, file_id: str) -> Response:
         """Read the content of a file from the server.
 
         Args:
@@ -57,7 +59,7 @@ class FilesRouter:
         except Exception as e:
             raise to_genai_error(e)
 
-    def delete_file(self, file_id: str):
+    def delete_file(self, file_id: str) -> Response:
         """Delete a file from the server.
 
         Args:
@@ -72,7 +74,7 @@ class FilesRouter:
         except Exception as e:
             raise to_genai_error(e)
 
-    def upload_file(self, multipart_form_data: MultipartFormData):
+    def upload_file(self, multipart_form_data: MultipartFormData) -> Response:
         """Upload a file to the server.
 
         Args:

--- a/src/genai/schemas/responses.py
+++ b/src/genai/schemas/responses.py
@@ -197,7 +197,7 @@ class FileFormatResult(GenAiResponseModel):
 
 class FileInfoResult(GenAiResponseModel):
     id: str
-    bytes: str
+    bytes: int
     file_name: str
     purpose: str
     storage_provider_location: Optional[str] = None

--- a/src/genai/services/file_manager.py
+++ b/src/genai/services/file_manager.py
@@ -39,7 +39,7 @@ class FileManager:
         try:
             response = service._files.list_files(params=params)
 
-            if response.status_code == 200:
+            if response.is_success:
                 response = response.json()
                 responses = FilesListResponse(**response)
                 return responses
@@ -69,7 +69,7 @@ class FileManager:
         try:
             response = service._files.get_file_metadata(file_id=file_id)
 
-            if response.status_code == 200:
+            if response.is_success:
                 response = response.json()
                 return FileInfoResult(**response["results"])
             else:
@@ -96,7 +96,7 @@ class FileManager:
         try:
             response = service._files.read_file(file_id=file_id)
 
-            if response.status_code == 200:
+            if response.is_success:
                 return response.content.decode("utf-8")
             else:
                 raise GenAiException(response)
@@ -151,7 +151,7 @@ class FileManager:
         try:
             response = service._files.upload_file(multipart_form_data=multipart_form_data)
 
-            if response.status_code == 201:
+            if response.is_success:
                 response = response.json()
                 return FileInfoResult(**response["results"])
             else:
@@ -177,7 +177,7 @@ class FileManager:
 
         try:
             response = service._files.delete_file(file_id=file_id)
-            if response.status_code == 204:
+            if response.is_success:
                 return {"status": "success"}
             else:
                 raise GenAiException(response)


### PR DESCRIPTION
## Status
**READY**

## Description

Due to the wrong type for the file's `bytes` field, the validations fail and throw.
This PR fixes that and adds an example which also suits as a test case.

## Impacted Areas in Library
Files