### PR TITLE
fix: integration tests / async error logging

### DIFF
--- a/examples/dev/history-async.py
+++ b/examples/dev/history-async.py
@@ -14,7 +14,7 @@ api_key = os.getenv("GENAI_KEY")
 SERVICE_URL = "https://workbench-api.res.ibm.com"
 
 service = ServiceInterface(service_url=SERVICE_URL, api_key=api_key)
-model = "google/ul2"
+model = "google/flan-ul2"
 inputs = ["Hello! How are you today?"]
 
 params = HistoryParams(

--- a/examples/dev/load_token_env.py
+++ b/examples/dev/load_token_env.py
@@ -11,5 +11,5 @@ load_dotenv()
 SERVICE_URL = "https://workbench-api.res.ibm.com"
 GENAI_KEY = os.getenv("GENAI_KEY")
 service = ServiceInterface(service_url=SERVICE_URL, api_key=GENAI_KEY)
-completion = service.generate("google/ul2", ["hello! How are you?"])
+completion = service.generate("google/flan-ul2", ["hello! How are you?"])
 print(completion)

--- a/examples/user/model_as_string.py
+++ b/examples/user/model_as_string.py
@@ -18,7 +18,7 @@ params = GenerateParams(decoding_method="sample", max_new_tokens=10)
 
 # model object
 flan = Model("google/flan-ul2", params=params, credentials=creds)
-ul2 = Model("google/ul2", params=params, credentials=creds)
+ul2 = Model("google/flan-ul2", params=params, credentials=creds)
 t5 = Model("google/flan-t5-xl", params=params, credentials=creds)
 
 # Q&A with flan-ul2
@@ -29,7 +29,7 @@ for response in flan.generate_async(prompts):
 
 # Q&A with ul2
 print("\n------------- Example (Input ul2 model as string)-------------\n")
-for response in ul2.generate_async(prompts):
+for response in ul2.generate_async(prompts, throw_on_error=True):
     print(f"Prompt: {response.input_text}\nResponse: {response.generated_text}")
 
 # Q&A with gpt

--- a/examples/user/model_utils.py
+++ b/examples/user/model_utils.py
@@ -18,12 +18,12 @@ for m in Model.models(credentials=creds):
     print(m)
 
 print("====== Checking model availability =======")
-model = Model("google/ul2", params=None, credentials=creds)
-print("Model availability for 'google/ul2': ", model.available())
+model = Model("google/flan-ul2", params=None, credentials=creds)
+print("Model availability for 'google/flan-ul2': ", model.available())
 
 model = Model("random", params=None, credentials=creds)
 print("Model availability for 'random': ", model.available())
 
 print("====== Display model card =======")
-model = Model("google/ul2", params=None, credentials=creds)
-print("Model info for 'google/ul2': \n", model.info())
+model = Model("google/flan-ul2", params=None, credentials=creds)
+print("Model info for 'google/flan-ul2': \n", model.info())

--- a/src/genai/services/async_generator.py
+++ b/src/genai/services/async_generator.py
@@ -120,7 +120,7 @@ class AsyncResponseGenerator:
         try:
             response_raw = await self._service_fn(model, inputs, params, options)
             response = response_raw.json()
-            if response_raw and (200 < response_raw.status_code or response_raw.status_code > 299):
+            if response_raw and not response_raw.is_success:
                 raise Exception(response)
         except Exception as ex:
             logger.error("Error in _get_response_json {}: {}".format(type(ex), str(ex)))

--- a/tests/assets/response_helper.py
+++ b/tests/assets/response_helper.py
@@ -127,12 +127,12 @@ class SimpleResponse:
                     "duration": 431,
                     "request": {
                         "inputs": ["Write a tagline for an alumni association: Together we"],
-                        "model_id": "google/ul2",
+                        "model_id": "google/flan-ul2",
                         "parameters": {},
                     },
                     "status": "SUCCESS",
                     "created_at": "2022-12-19T22:53:22.000Z",
-                    "response": SimpleResponse.generate(model="google/ul2", inputs=["some input"]),
+                    "response": SimpleResponse.generate(model="google/flan-ul2", inputs=["some input"]),
                 }
             ],
             "totalCount": 62,

--- a/tests/extensions/test_langchain.py
+++ b/tests/extensions/test_langchain.py
@@ -17,7 +17,7 @@ from tests.utils import match_endpoint
 class TestLangChain:
     def setup_method(self):
         self.service = ServiceInterface(service_url="SERVICE_URL", api_key="API_KEY")
-        self.model = "google/ul2"
+        self.model = "google/flan-ul2"
         self.inputs = ["Write a tagline for an alumni association: Together we"]
 
     @pytest.fixture

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 class TestAsyncResponseGenerator:
     def setup_method(self):
         self.service = ServiceInterface(service_url="http://SERVICE_URL", api_key="API_KEY")
-        self.model = "google/ul2"
+        self.model = "google/flan-ul2"
         self.inputs = ["Write a tagline for an alumni association: Together we"]
 
     @pytest.fixture

--- a/tests/test_generate_schema.py
+++ b/tests/test_generate_schema.py
@@ -10,7 +10,7 @@ from genai.schemas import GenerateParams, LengthPenalty, Return, ReturnOptions
 class TestGenerateSchema:
     def setup_method(self):
         # mock object for the API call
-        self.model = "google/ul2"
+        self.model = "google/flan-ul2"
         self.inputs = ["Write a tagline for an alumni association: Together we"]
 
         # test all GenerateParams fields

--- a/tests/test_generate_service.py
+++ b/tests/test_generate_service.py
@@ -14,7 +14,7 @@ from tests.utils import match_endpoint
 class TestGenerateService:
     def setup_method(self):
         self.service = ServiceInterface(service_url="http://service_url", api_key="API_KEY")
-        self.model = "google/ul2"
+        self.model = "google/flan-ul2"
         self.inputs = ["Write a tagline for an alumni association: Together we"]
 
     @pytest.fixture

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -22,7 +22,7 @@ class TestModel:
     def setup_method(self):
         self.creds = Credentials(api_key="API_KEY")
         self.service = ServiceInterface(service_url="http://service_url", api_key="API_KEY")
-        self.model = "google/ul2"
+        self.model = "google/flan-ul2"
         self.inputs = ["Write a tagline for an alumni association: Together we"]
 
     @pytest.fixture

--- a/tests/test_model_async.py
+++ b/tests/test_model_async.py
@@ -20,7 +20,7 @@ class TestModelAsync:
     def setup_method(self):
         self.service = ServiceInterface(service_url="http://service_url", api_key="API_KEY")
         self.creds = Credentials("TEST_API_KEY")
-        self.model = "google/ul2"
+        self.model = "google/flan-ul2"
         self.inputs = ["Write a tagline for an alumni association: Together we"]
 
     @pytest.fixture

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class TestSchemas:
     def setup_method(self):
         self.service = ServiceInterface(service_url="SERVICE_URL", api_key="API_KEY")
-        self.model = "google/ul2"
+        self.model = "google/flan-ul2"
         self.inputs = ["Write a tagline for an alumni association: Together we"]
 
     def _validate_extra_field(self, input_dict, model_type):

--- a/tests/test_service_interface.py
+++ b/tests/test_service_interface.py
@@ -13,7 +13,7 @@ class TestServiceInterface:
     def setup_method(self):
         # mock object for the API call
         self.service = ServiceInterface(service_url="http://service_url", api_key="API_KEY")
-        self.model = "google/ul2"
+        self.model = "google/flan-ul2"
         self.inputs = ["Write a tagline for an alumni association: Together we"]
 
     @pytest.fixture

--- a/tests/test_service_interface_async.py
+++ b/tests/test_service_interface_async.py
@@ -21,7 +21,7 @@ class TestServiceInterfaceAsync:
     def setup_method(self):
         # mock object for the API call
         self.service = ServiceInterface(service_url="http://SERVICE_URL", api_key="API_KEY")
-        self.model = "google/ul2"
+        self.model = "google/flan-ul2"
         self.inputs = ["Write a tagline for an alumni association: Together we"]
 
     # GENERATE ASYNC

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -17,7 +17,7 @@ class TestTokenize:
     def setup_method(self):
         # mock object for the API call
         self.service = ServiceInterface(service_url="http://service_url", api_key="API_KEY")
-        self.model = "google/ul2"
+        self.model = "google/flan-ul2"
         self.inputs = ["Write a tagline for an alumni association: Together we"]
 
     @pytest.fixture


### PR DESCRIPTION
## Status
**READY**

## Description

- Replace deprecated/renamed model `google/ul2` to it's newer version `google/flan-ul2`.
- Improve handling of errors in case of `async` processing -> logs the response body


## Impacted Areas in Library
Tests, Async Generate
