### PR TITLE
feat: improve response errors formatting

### DIFF
--- a/src/genai/exceptions/genai_exception.py
+++ b/src/genai/exceptions/genai_exception.py
@@ -17,7 +17,7 @@ class GenAiException(Exception):
         elif isinstance(error, Response):
             try:
                 self.error = ErrorResponse(**error.json())
-                self.error_message = self.error.message
+                self.error_message = self.error.model_dump_json()
             except ValidationError:
                 self.error = error
                 self.error_message = str(error.content)

--- a/src/genai/services/async_generator.py
+++ b/src/genai/services/async_generator.py
@@ -121,7 +121,7 @@ class AsyncResponseGenerator:
             response_raw = await self._service_fn(model, inputs, params, options)
             response = response_raw.json()
             if response_raw and not response_raw.is_success:
-                raise Exception(response)
+                raise GenAiException(response)
         except Exception as ex:
             logger.error("Error in _get_response_json {}: {}".format(type(ex), str(ex)))
             if self.throw_on_error:

--- a/src/genai/utils/http_utils.py
+++ b/src/genai/utils/http_utils.py
@@ -55,7 +55,7 @@ class AsyncRetryTransport(httpx.AsyncHTTPTransport):
 
                 if ex.response and "application/json" in ex.response.headers["Content-Type"]:
                     await ex.response.aread()
-                    raise GenAiException(ex.response)
+                    raise GenAiException(ex.response) from None
                 else:
                     raise ex
 


### PR DESCRIPTION
Currently, we throw errors like this one,

```
GenAiException: Client error '400 Bad Request' for url 'https://workbench-api.res.ibm.com/v1/generate'
For more information check: https://httpstatuses.com/400
```

however, we want to throw errors which would explain the real cause, like this:


```
genai.exceptions.genai_exception.GenAiException: {"status_code":400,"error":"Bad Request","message":"Invalid argument or out of range","extensions":{"code":"INVALID_INPUT","state":null,"reason":"3 INVALID_ARGUMENT: input tokens (35000) plus prefix length (0) must be < 4096"}}
```

Note: this is for the `generate_async` method. 
For the `generate` method it works as expected without further changes