### PR TITLE
fix: external limiter implementation

### DIFF
--- a/src/genai/_utils/async_executor.py
+++ b/src/genai/_utils/async_executor.py
@@ -78,15 +78,13 @@ class _AsyncGenerator(Generic[TInput, TResult]):
         client: AsyncHttpxClient,
     ):
         async with limiter:
-            logger.debug("Creating task for batch_num {}".format(batch_num))
+            logger.debug(f"Creating task for batch_num: {batch_num}")
             try:
                 response = await self._handler(input, client, limiter)
                 logger.debug("Received response = {}".format(response))
                 self._add_to_queue(idx=batch_num, result=response, error=None)
             except Exception as e:
-                logger.error(
-                    f"Exception raised async_generate and casting : {str(e)}, response = {None}, inputs = {input}"
-                )
+                logger.error(f"Exception raised during processing\n{str(e)}")
                 self._add_to_queue(idx=batch_num, result=None, error=e)
 
     async def _schedule_requests(self, limiter: BaseLimiter, loop: AbstractEventLoop):

--- a/src/genai/_utils/limiters/adjustable_semaphor.py
+++ b/src/genai/_utils/limiters/adjustable_semaphor.py
@@ -16,6 +16,7 @@ class AdjustableAsyncSemaphore(AsyncioSemaphore):
         super().__init__(value)
         self._max_limit = value
         self._waiters = deque()
+        self._processing = 0
         self._dummy_waiters: set[Future] = set()
 
     @property
@@ -24,10 +25,7 @@ class AdjustableAsyncSemaphore(AsyncioSemaphore):
 
     @property
     def processing(self):
-        if self._value > 0:
-            return 0
-
-        return self._max_limit - self._value
+        return self._processing
 
     @property
     def waiting(self):
@@ -38,8 +36,10 @@ class AdjustableAsyncSemaphore(AsyncioSemaphore):
 
     async def acquire(self):
         """Taken from Python 3.11"""
+
         if not self.locked():
             self._value -= 1
+            self._processing += 1
             return True
 
         fut = self._get_loop().create_future()
@@ -56,6 +56,7 @@ class AdjustableAsyncSemaphore(AsyncioSemaphore):
         except CancelledError:
             if not fut.cancelled():
                 self._value += 1
+                self._processing -= 1
                 self._wake_up_next()
             raise
 
@@ -66,6 +67,7 @@ class AdjustableAsyncSemaphore(AsyncioSemaphore):
     def release(self):
         """Taken from Python 3.11"""
         self._value += 1
+        self._processing -= 1
         self._wake_up_next()
 
     def _wake_up_next(self):
@@ -76,6 +78,8 @@ class AdjustableAsyncSemaphore(AsyncioSemaphore):
         for fut in self._waiters:
             if not fut.done():
                 self._value -= 1
+                if fut not in self._dummy_waiters:
+                    self._processing += 1
                 fut.set_result(True)
                 return
 
@@ -99,16 +103,15 @@ class AdjustableAsyncSemaphore(AsyncioSemaphore):
             return False
 
         old_limit = self._max_limit
-        free_capacity = self._value
-        future_capacity = free_capacity if free_capacity > 0 else old_limit
         self._max_limit = new_limit
 
         if new_limit > old_limit:
-            points_to_add = new_limit - future_capacity
+            points_to_add = new_limit - old_limit
             for _ in range(0, points_to_add):
+                self._processing += 1
                 self.release()
         else:
-            points_to_remove = future_capacity - new_limit
+            points_to_remove = old_limit - new_limit
 
             for _ in range(0, points_to_remove):
                 if self.locked():
@@ -117,14 +120,16 @@ class AdjustableAsyncSemaphore(AsyncioSemaphore):
                     def handle_done(f: Future):
                         assert f.done()
 
-                        with suppress(KeyError):
-                            self._dummy_waiters.remove(f)
                         with suppress(ValueError):
                             self._waiters.remove(f)
 
                         if self._value > 0:
                             self._value -= 1
+                            self._processing += 1
                             self.release()
+
+                        with suppress(KeyError):
+                            self._dummy_waiters.remove(f)
 
                     fut.add_done_callback(handle_done)
 

--- a/src/genai/_utils/limiters/adjustable_semaphor.py
+++ b/src/genai/_utils/limiters/adjustable_semaphor.py
@@ -97,7 +97,7 @@ class AdjustableAsyncSemaphore(AsyncioSemaphore):
             ValueError: If `new_limit` is less than 0.
         """
         if new_limit < 0:
-            raise ValueError("Semaphore concurrency cannot be less than 1!")
+            raise ValueError("Semaphore concurrency cannot be less than 0!")
 
         if new_limit == self._max_limit:
             return False
@@ -124,9 +124,7 @@ class AdjustableAsyncSemaphore(AsyncioSemaphore):
                             self._waiters.remove(f)
 
                         if self._value > 0:
-                            self._value -= 1
-                            self._processing += 1
-                            self.release()
+                            self._wake_up_next()
 
                         with suppress(KeyError):
                             self._dummy_waiters.remove(f)

--- a/src/genai/_utils/limiters/base_limiter.py
+++ b/src/genai/_utils/limiters/base_limiter.py
@@ -10,11 +10,13 @@ class BaseLimiter(ABC):
     def release(self):
         ...
 
-    async def report_error(self):  # noqa: B027 # empty body without being abstract
-        pass
+    @abstractmethod
+    async def report_error(self):
+        ...
 
-    async def report_success(self):  # noqa: B027 # empty body without being abstract
-        pass
+    @abstractmethod
+    async def report_success(self):
+        ...
 
     async def __aenter__(self):
         await self.acquire()

--- a/src/genai/_utils/limiters/external_limiter.py
+++ b/src/genai/_utils/limiters/external_limiter.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 from typing import Awaitable, Callable
 
 from pydantic import BaseModel, Field
@@ -5,6 +7,8 @@ from pydantic import BaseModel, Field
 from genai._utils.asyncio_future import AsyncioLock
 from genai._utils.limiters.adjustable_semaphor import AdjustableAsyncSemaphore
 from genai._utils.limiters.base_limiter import BaseLimiter
+
+__all__ = ["ExternalLimiter", "ExternalLimiterHandler", "ConcurrencyResponse"]
 
 
 class ConcurrencyResponse(BaseModel):
@@ -18,45 +22,56 @@ ExternalLimiterHandler = Callable[[], Awaitable[ConcurrencyResponse]]
 class ExternalLimiter(BaseLimiter):
     """A limiter class that interacts with an external handler to enforce dynamic concurrent limits."""
 
+    limit_block_recheck_internal_ms: int = 100
+
     def __init__(self, *, handler: ExternalLimiterHandler):
         self._handler = handler
         self._lock = AsyncioLock()
         self._sp = AdjustableAsyncSemaphore(0)
-        self._last_retrieved_limit = 0
+        self._max_limit = 0
         self._synced = False
+        self._logger = logging.getLogger(self.__module__)
+
+    def _change_limit(self, new_limit: int):
+        old_limit = self._sp.limit
+
+        limit_has_changed = self._sp.change_max_limit(new_limit)
+        if limit_has_changed:
+            self._logger.debug(f"Changing limit from {old_limit} to {new_limit}")
 
     async def report_error(self):
-        """
-        Decrease current limit by one (if possible)
-        """
-        limit_has_changed = await self.resync()
-        current_limit = self._sp.limit
-        if not limit_has_changed and current_limit > 1:
-            self._sp.change_max_limit(current_limit - 1)
+        """Decrease current limit by one"""
+        if not self._synced:
+            return
+
+        new_limit = 1
+        self._change_limit(new_limit)
 
     async def report_success(self):
-        """
-        Increase current limit by one in case it has been decreased previously
-        """
-        new_limit = min(self._last_retrieved_limit, self._sp.limit + 1)
-        self._sp.change_max_limit(new_limit)
+        """Increase current limit by one in case it has been decreased previously"""
+        if not self._synced:
+            return
 
-    async def resync(self) -> bool:
-        """
-        Asynchronously resynchronizes the limit by calling provided handler.
-        """
-        response = await self._handler()
-        limit_has_changed = self._sp.change_max_limit(response.limit)
-        if limit_has_changed:
-            self._last_retrieved_limit = response.limit
-
-        return limit_has_changed
+        new_limit = min(self._max_limit, self._sp.limit + 1)
+        self._change_limit(new_limit)
 
     async def acquire(self):
         async with self._lock:
             if not self._synced:
-                await self.resync()
                 self._synced = True
+
+                response = await self._handler()
+                while response.remaining <= 0:
+                    self._logger.warning(
+                        "You can't send more requests due to the API concurrency limit. "
+                        "There is another running process (probably). "
+                        f"Retrying in {self.limit_block_recheck_internal_ms} ms."
+                    )
+                    await asyncio.sleep(self.limit_block_recheck_internal_ms / 1000)
+                    response = await self._handler()
+
+                self._max_limit = response.limit
+                self._change_limit(response.remaining)
 
         await self._sp.acquire()
         return True

--- a/src/genai/_utils/limiters/shared_limiter.py
+++ b/src/genai/_utils/limiters/shared_limiter.py
@@ -22,6 +22,12 @@ class LoopBoundLimiter(BaseLimiter):
     def release(self):
         return self._get_limiter().release()
 
+    async def report_error(self):
+        return await self._limiter.report_error()
+
+    async def report_success(self):
+        return await self._limiter.report_success()
+
     def _get_limiter(self) -> BaseLimiter:
         loop = asyncio.get_running_loop()
         if loop is not self._loop:

--- a/tests/unit/utils/limiters/test_adjustable_semaphor.py
+++ b/tests/unit/utils/limiters/test_adjustable_semaphor.py
@@ -41,6 +41,15 @@ logger = logging.getLogger()
 @pytest.mark.unit
 class TestAdjustableSemaphore:
     @pytest.mark.asyncio
+    async def test_limit_edge_case(self):
+        semaphore = AdjustableAsyncSemaphore(0)
+        for new_limit in [5, 10, 15, 1, 2]:
+            semaphore.change_max_limit(new_limit)
+            assert semaphore.limit == new_limit
+            assert semaphore.waiting == 0
+            assert semaphore.processing == 0
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "state",
         [


### PR DESCRIPTION
- add missing handlers for error/success reporting
- fix the `retries` property in transport (allow 0)
- handle changing limits on `AsyncSemaphore` when no tasks are being processed
- set the initial limit to the number of remaining limits (not the maximal one)
- set limit to 1 in case of an error