### PR TITLE
typo: fix bam api url in documentation

### DIFF
--- a/src/genai/credentials.py
+++ b/src/genai/credentials.py
@@ -16,7 +16,7 @@ class Credentials(BaseModel):
     Examples:
         Create a Credentials instance with explicit api_endpoint::
 
-            credentials = Credentials(api_key="your_api_key", api_endpoint="https://bam-api.res.ibm")
+            credentials = Credentials(api_key="your_api_key", api_endpoint="https://bam-api.res.ibm.com")
 
         Create a Credentials instance with default api_endpoint::
 


### PR DESCRIPTION
## Status

READY

## Description

The default api_endpoint is "https://bam-api.res.ibm.com", but even the small ".com" typo can be confusing to some why it's not working, and can easily get ignored while trying to find the issue

## Impacted Areas in Library

None, it's a documentation change

## Which issue(s) does this pull-request fix?

Directly created this PR, I will create an Issue for this.

## Any special notes for your reviewer?


## Checklist
- [ ] Automated tests exist
- [ ] Updated Package Requirements (if required, and with maintainers' approval)
- [ ] Local unit tests performed
- [ ] Documentation exists [link]()
- [ ] Local pre-commit hooks performed
- [ ] Desired commit message set as PR title and description set above
- [ ] Link to relevant GitHub issue provided
