### PR TITLE
docs: switch to sphinx-multiversion fork

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -88,8 +88,7 @@ smv_prebuild_command = " && ".join(
         "cd ..",  # go to the project root
         "make -C documentation/ apidoc",  # generates `modules` index
         "export PYTHONPATH='scripts'",
-        "export BRANCH_NAME=\"$(cat ../versions.json | jq -r --arg DIR_NAME `basename $PWD` '.[] | select(.basedir | endswith($DIR_NAME)) | .name')\"",  # noqa
-        f'export BRANCH_NAME="${{BRANCH_NAME:-{smv_latest_version}}}"',  # noqa
+        'export BRANCH_NAME="$SPHINX_MULTIVERSION_NAME"',
         "python scripts/docs_examples_generator/main.py",
         "([ -f scripts/docs_fix_schema_private.sh ] && ./scripts/docs_fix_schema_private.sh) || ([ ! -f scripts/docs_fix_schema_private.sh ] && echo 'Skip docs fix schema private (does not exists)')",  # noqa
     ]

--- a/external/sphinx_multiversion/README.md
+++ b/external/sphinx_multiversion/README.md
@@ -1,0 +1,29 @@
+The modified version of original `sphinx-multiversion` [repository](https://github.com/Holzhaus/sphinx-multiversion) which is licenses under the BSD 2-Clause "Simplified" License.
+
+```
+BSD 2-Clause License
+
+Copyright (c) 2020, Jan Holthuis <jan.holthuis@ruhr-uni-bochum.de>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/external/sphinx_multiversion/setup.py
+++ b/external/sphinx_multiversion/setup.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from setuptools import setup
+
+setup(
+    name="sphinx-multiversion",
+    description="Add support for multiple versions to sphinx",
+    classifiers=[
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
+    author="Jan Holthuis",
+    author_email="holthuis.jan@googlemail.com",
+    url="https://holzhaus.github.io/sphinx-multiversion/",
+    version="0.2.4",
+    install_requires=["sphinx >= 2.1"],
+    license="BSD",
+    packages=["sphinx_multiversion"],
+    entry_points={
+        "console_scripts": [
+            "sphinx-multiversion=sphinx_multiversion:main",
+        ],
+    },
+)

--- a/external/sphinx_multiversion/sphinx_multiversion/__init__.py
+++ b/external/sphinx_multiversion/sphinx_multiversion/__init__.py
@@ -1,0 +1,14 @@
+# This file contains code modified from the 'sphinx-multiversion' project
+# Original author: Jan Holthuis
+# The original code is licensed under the BSD 2-Clause "Simplified" License.
+
+# -*- coding: utf-8 -*-
+from .main import main
+from .sphinx import setup
+
+__version__ = "0.2.4"
+
+__all__ = [
+    "setup",
+    "main",
+]

--- a/external/sphinx_multiversion/sphinx_multiversion/__main__.py
+++ b/external/sphinx_multiversion/sphinx_multiversion/__main__.py
@@ -1,0 +1,11 @@
+# This file contains code modified from the 'sphinx-multiversion' project
+# Original author: Jan Holthuis
+# The original code is licensed under the BSD 2-Clause "Simplified" License.
+
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import sys
+
+from .main import main
+
+sys.exit(main())

--- a/external/sphinx_multiversion/sphinx_multiversion/git.py
+++ b/external/sphinx_multiversion/sphinx_multiversion/git.py
@@ -1,0 +1,153 @@
+# This file contains code modified from the 'sphinx-multiversion' project
+# Original author: Jan Holthuis
+# The original code is licensed under the BSD 2-Clause "Simplified" License.
+
+# -*- coding: utf-8 -*-
+import collections
+import datetime
+import logging
+import os
+import re
+import subprocess
+import tarfile
+import tempfile
+
+GitRef = collections.namedtuple(
+    "VersionRef",
+    [
+        "name",
+        "commit",
+        "source",
+        "is_remote",
+        "refname",
+        "creatordate",
+    ],
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_toplevel_path(cwd=None):
+    cmd = (
+        "git",
+        "rev-parse",
+        "--show-toplevel",
+    )
+    output = subprocess.check_output(cmd, cwd=cwd).decode()
+    return output.rstrip("\n")
+
+
+def get_all_refs(gitroot):
+    cmd = (
+        "git",
+        "for-each-ref",
+        "--format",
+        "%(objectname)\t%(refname)\t%(creatordate:iso)",
+        "refs",
+    )
+    output = subprocess.check_output(cmd, cwd=gitroot).decode()
+    for line in output.splitlines():
+        is_remote = False
+        fields = line.strip().split("\t")
+        if len(fields) != 3:
+            continue
+
+        commit = fields[0]
+        refname = fields[1]
+        creatordate = datetime.datetime.strptime(fields[2], "%Y-%m-%d %H:%M:%S %z")
+
+        # Parse refname
+        matchobj = re.match(r"^refs/(heads|tags|remotes/[^/]+)/(\S+)$", refname)
+        if not matchobj:
+            continue
+        source = matchobj.group(1)
+        name = matchobj.group(2)
+
+        if source.startswith("remotes/"):
+            is_remote = True
+
+        yield GitRef(name, commit, source, is_remote, refname, creatordate)
+
+
+def get_refs(gitroot, tag_whitelist, branch_whitelist, remote_whitelist, files=()):
+    for ref in get_all_refs(gitroot):
+        if ref.source == "tags":
+            if tag_whitelist is None or not re.match(tag_whitelist, ref.name):
+                logger.debug(
+                    "Skipping '%s' because tag '%s' doesn't match the " "whitelist pattern",
+                    ref.refname,
+                    ref.name,
+                )
+                continue
+        elif ref.source == "heads":
+            if branch_whitelist is None or not re.match(branch_whitelist, ref.name):
+                logger.debug(
+                    "Skipping '%s' because branch '%s' doesn't match the " "whitelist pattern",
+                    ref.refname,
+                    ref.name,
+                )
+                continue
+        elif ref.is_remote and remote_whitelist is not None:
+            remote_name = ref.source.partition("/")[2]
+            if not re.match(remote_whitelist, remote_name):
+                logger.debug(
+                    "Skipping '%s' because remote '%s' doesn't match the " "whitelist pattern",
+                    ref.refname,
+                    remote_name,
+                )
+                continue
+            if branch_whitelist is None or not re.match(branch_whitelist, ref.name):
+                logger.debug(
+                    "Skipping '%s' because branch '%s' doesn't match the " "whitelist pattern",
+                    ref.refname,
+                    ref.name,
+                )
+                continue
+        else:
+            logger.debug("Skipping '%s' because its not a branch or tag", ref.refname)
+            continue
+
+        missing_files = [
+            filename for filename in files if filename != "." and not file_exists(gitroot, ref.refname, filename)
+        ]
+        if missing_files:
+            logger.debug(
+                "Skipping '%s' because it lacks required files: %r",
+                ref.refname,
+                missing_files,
+            )
+            continue
+
+        yield ref
+
+
+def file_exists(gitroot, refname, filename):
+    if os.sep != "/":
+        # Git requires / path sep, make sure we use that
+        filename = filename.replace(os.sep, "/")
+
+    cmd = (
+        "git",
+        "cat-file",
+        "-e",
+        "{}:{}".format(refname, filename),
+    )
+    proc = subprocess.run(cmd, cwd=gitroot, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return proc.returncode == 0
+
+
+def copy_tree(gitroot, src, dst, reference, sourcepath="."):
+    with tempfile.SpooledTemporaryFile() as fp:
+        cmd = (
+            "git",
+            "archive",
+            "--format",
+            "tar",
+            reference.commit,
+            "--",
+            sourcepath,
+        )
+        subprocess.check_call(cmd, cwd=gitroot, stdout=fp)
+        fp.seek(0)
+        with tarfile.TarFile(fileobj=fp) as tarfp:
+            tarfp.extractall(dst)

--- a/external/sphinx_multiversion/sphinx_multiversion/main.py
+++ b/external/sphinx_multiversion/sphinx_multiversion/main.py
@@ -1,0 +1,346 @@
+# This file contains code modified from the 'sphinx-multiversion' project
+# Original author: Jan Holthuis
+# The original code is licensed under the BSD 2-Clause "Simplified" License.
+
+# -*- coding: utf-8 -*-
+import argparse
+import contextlib
+import itertools
+import json
+import logging
+import multiprocessing
+import os
+import pathlib
+import re
+import string
+import subprocess
+import sys
+import tempfile
+
+from sphinx import config as sphinx_config
+from sphinx import project as sphinx_project
+
+from . import git, sphinx
+
+
+@contextlib.contextmanager
+def working_dir(path):
+    prev_cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)
+
+
+def load_sphinx_config_worker(q, confpath, confoverrides, add_defaults):
+    try:
+        with working_dir(confpath):
+            current_config = sphinx_config.Config.read(
+                confpath,
+                confoverrides,
+            )
+
+        if add_defaults:
+            current_config.add("smv_tag_whitelist", sphinx.DEFAULT_TAG_WHITELIST, "html", str)
+            current_config.add(
+                "smv_branch_whitelist",
+                sphinx.DEFAULT_TAG_WHITELIST,
+                "html",
+                str,
+            )
+            current_config.add(
+                "smv_remote_whitelist",
+                sphinx.DEFAULT_REMOTE_WHITELIST,
+                "html",
+                str,
+            )
+            current_config.add(
+                "smv_released_pattern",
+                sphinx.DEFAULT_RELEASED_PATTERN,
+                "html",
+                str,
+            )
+            current_config.add(
+                "smv_outputdir_format",
+                sphinx.DEFAULT_OUTPUTDIR_FORMAT,
+                "html",
+                str,
+            )
+            current_config.add("smv_prefer_remote_refs", False, "html", bool)
+            current_config.add("smv_prebuild_command", "", "html", str)
+            current_config.add("smv_postbuild_command", "", "html", str)
+        current_config.pre_init_values()
+        current_config.init_values()
+    except Exception as err:
+        q.put(err)
+        return
+
+    q.put(current_config)
+
+
+def load_sphinx_config(confpath, confoverrides, add_defaults=False):
+    q = multiprocessing.Queue()
+    proc = multiprocessing.Process(
+        target=load_sphinx_config_worker,
+        args=(q, confpath, confoverrides, add_defaults),
+    )
+    proc.start()
+    proc.join()
+    result = q.get_nowait()
+    if isinstance(result, Exception):
+        raise result
+    return result
+
+
+def get_python_flags():
+    if sys.flags.bytes_warning:
+        yield "-b"
+    if sys.flags.debug:
+        yield "-d"
+    if sys.flags.hash_randomization:
+        yield "-R"
+    if sys.flags.ignore_environment:
+        yield "-E"
+    if sys.flags.inspect:
+        yield "-i"
+    if sys.flags.isolated:
+        yield "-I"
+    if sys.flags.no_site:
+        yield "-S"
+    if sys.flags.no_user_site:
+        yield "-s"
+    if sys.flags.optimize:
+        yield "-O"
+    if sys.flags.quiet:
+        yield "-q"
+    if sys.flags.verbose:
+        yield "-v"
+    for option, value in sys._xoptions.items():
+        if value is True:
+            yield from ("-X", option)
+        else:
+            yield from ("-X", "{}={}".format(option, value))
+
+
+def main(argv=None):
+    if not argv:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sourcedir", help="path to documentation source files")
+    parser.add_argument("outputdir", help="path to output directory")
+    parser.add_argument(
+        "filenames",
+        nargs="*",
+        help="a list of specific files to rebuild. Ignored if -a is specified",
+    )
+    parser.add_argument(
+        "-c",
+        metavar="PATH",
+        dest="confdir",
+        help=("path where configuration file (conf.py) is located " "(default: same as SOURCEDIR)"),
+    )
+    parser.add_argument(
+        "-C",
+        action="store_true",
+        dest="noconfig",
+        help="use no config file at all, only -D options",
+    )
+    parser.add_argument(
+        "-D",
+        metavar="setting=value",
+        action="append",
+        dest="define",
+        default=[],
+        help="override a setting in configuration file",
+    )
+    parser.add_argument(
+        "--dump-metadata",
+        action="store_true",
+        help="dump generated metadata and exit",
+    )
+    args, argv = parser.parse_known_args(argv)
+    if args.noconfig:
+        return 1
+
+    logger = logging.getLogger(__name__)
+
+    sourcedir_absolute = os.path.abspath(args.sourcedir)
+    confdir_absolute = os.path.abspath(args.confdir) if args.confdir is not None else sourcedir_absolute
+
+    # Conf-overrides
+    confoverrides = {}
+    for d in args.define:
+        key, _, value = d.partition("=")
+        confoverrides[key] = value
+
+    # Parse config
+    config = load_sphinx_config(confdir_absolute, confoverrides, add_defaults=True)
+
+    # Get relative paths to root of git repository
+    gitroot = pathlib.Path(git.get_toplevel_path(cwd=sourcedir_absolute)).resolve()
+    cwd_absolute = os.path.abspath(".")
+    cwd_relative = os.path.relpath(cwd_absolute, str(gitroot))
+
+    logger.debug("Git toplevel path: %s", str(gitroot))
+    sourcedir = os.path.relpath(sourcedir_absolute, str(gitroot))
+    logger.debug("Source dir (relative to git toplevel path): %s", str(sourcedir))
+    if args.confdir:
+        confdir = os.path.relpath(confdir_absolute, str(gitroot))
+    else:
+        confdir = sourcedir
+    logger.debug("Conf dir (relative to git toplevel path): %s", str(confdir))
+    conffile = os.path.join(confdir, "conf.py")
+
+    # Get git references
+    gitrefs = git.get_refs(
+        str(gitroot),
+        config.smv_tag_whitelist,
+        config.smv_branch_whitelist,
+        config.smv_remote_whitelist,
+        files=(sourcedir, conffile),
+    )
+
+    # Order git refs
+    if config.smv_prefer_remote_refs:
+        gitrefs = sorted(gitrefs, key=lambda x: (not x.is_remote, *x))
+    else:
+        gitrefs = sorted(gitrefs, key=lambda x: (x.is_remote, *x))
+
+    logger = logging.getLogger(__name__)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # Generate Metadata
+        metadata = {}
+        outputdirs = set()
+        for gitref in gitrefs:
+            # Clone Git repo
+            repopath = os.path.join(tmp, gitref.commit)
+            try:
+                git.copy_tree(str(gitroot), gitroot.as_uri(), repopath, gitref)
+            except (OSError, subprocess.CalledProcessError):
+                logger.error(
+                    "Failed to copy git tree for %s to %s",
+                    gitref.refname,
+                    repopath,
+                )
+                continue
+
+            # Find config
+            confpath = os.path.join(repopath, confdir)
+            try:
+                current_config = load_sphinx_config(confpath, confoverrides)
+            except (OSError, sphinx_config.ConfigError):
+                logger.error(
+                    "Failed load config for %s from %s",
+                    gitref.refname,
+                    confpath,
+                )
+                continue
+
+            # Ensure that there are not duplicate output dirs
+            outputdir = config.smv_outputdir_format.format(
+                ref=gitref,
+                config=current_config,
+            )
+            if outputdir in outputdirs:
+                logger.warning(
+                    "outputdir '%s' for %s conflicts with other versions",
+                    outputdir,
+                    gitref.refname,
+                )
+                continue
+            outputdirs.add(outputdir)
+
+            # Get List of files
+            source_suffixes = current_config.source_suffix
+            if isinstance(source_suffixes, str):
+                source_suffixes = [current_config.source_suffix]
+
+            current_sourcedir = os.path.join(repopath, sourcedir)
+            project = sphinx_project.Project(current_sourcedir, source_suffixes)
+            metadata[gitref.name] = {
+                "name": gitref.name,
+                "version": current_config.version,
+                "release": current_config.release,
+                "rst_prolog": current_config.rst_prolog,
+                "is_released": bool(re.match(config.smv_released_pattern, gitref.refname)),
+                "source": gitref.source,
+                "creatordate": gitref.creatordate.strftime(sphinx.DATE_FMT),
+                "basedir": repopath,
+                "sourcedir": current_sourcedir,
+                "outputdir": os.path.join(os.path.abspath(args.outputdir), outputdir),
+                "confdir": confpath,
+                "docnames": list(project.discover()),
+            }
+
+        if args.dump_metadata:
+            print(json.dumps(metadata, indent=2))  # noqa
+            return 0
+
+        if not metadata:
+            logger.error("No matching refs found!")
+            return 2
+
+        # Write Metadata
+        metadata_path = os.path.abspath(os.path.join(tmp, "versions.json"))
+        with open(metadata_path, mode="w") as fp:
+            json.dump(metadata, fp, indent=2)
+
+        # Run Sphinx
+        argv.extend(["-D", "smv_metadata_path={}".format(metadata_path)])
+        for version_name, data in metadata.items():
+            os.makedirs(data["outputdir"], exist_ok=True)
+
+            defines = itertools.chain(*(("-D", string.Template(d).safe_substitute(data)) for d in args.define))
+
+            current_argv = argv.copy()
+            current_argv.extend(
+                [
+                    *defines,
+                    "-D",
+                    "smv_current_version={}".format(version_name),
+                    "-c",
+                    confdir_absolute,
+                    data["sourcedir"],
+                    data["outputdir"],
+                    *args.filenames,
+                ]
+            )
+
+            current_cwd = os.path.join(data["basedir"], cwd_relative)
+            env = os.environ.copy()
+            env.update(
+                {
+                    "SPHINX_MULTIVERSION_NAME": data["name"],
+                    "SPHINX_MULTIVERSION_VERSION": data["version"],
+                    "SPHINX_MULTIVERSION_RELEASE": data["release"],
+                    "SPHINX_MULTIVERSION_SOURCEDIR": data["sourcedir"],
+                    "SPHINX_MULTIVERSION_OUTPUTDIR": data["outputdir"],
+                    "SPHINX_MULTIVERSION_CONFDIR": data["confdir"],
+                }
+            )
+
+            if config.smv_prebuild_command:
+                logger.debug("Running prebuild command: %r", config.smv_prebuild_command)
+                subprocess.check_call(config.smv_prebuild_command, cwd=current_cwd, shell=True, env=env)
+
+            logger.debug("Running sphinx-build with args: %r", current_argv)
+            cmd = (
+                sys.executable,
+                *get_python_flags(),
+                "-m",
+                "sphinx",
+                *current_argv,
+            )
+            subprocess.check_call(cmd, cwd=current_cwd, env=env)
+
+            if config.smv_postbuild_command:
+                logger.debug(
+                    "Running postbuild command: %r",
+                    config.smv_postbuild_command,
+                )
+                subprocess.check_call(config.smv_postbuild_command, cwd=current_cwd, shell=True, env=env)
+
+    return 0

--- a/external/sphinx_multiversion/sphinx_multiversion/sphinx.py
+++ b/external/sphinx_multiversion/sphinx_multiversion/sphinx.py
@@ -1,0 +1,185 @@
+# This file contains code modified from the 'sphinx-multiversion' project
+# Original author: Jan Holthuis
+# The original code is licensed under the BSD 2-Clause "Simplified" License.
+
+# -*- coding: utf-8 -*-
+import collections
+import datetime
+import json
+import logging
+import os
+import posixpath
+
+from sphinx import config as sphinx_config
+from sphinx.locale import _
+from sphinx.util import i18n as sphinx_i18n
+
+logger = logging.getLogger(__name__)
+
+DATE_FMT = "%Y-%m-%d %H:%M:%S %z"
+DEFAULT_TAG_WHITELIST = r"^.*$"
+DEFAULT_BRANCH_WHITELIST = r"^.*$"
+DEFAULT_REMOTE_WHITELIST = None
+DEFAULT_RELEASED_PATTERN = r"^tags/.*$"
+DEFAULT_OUTPUTDIR_FORMAT = r"{ref.name}"
+
+Version = collections.namedtuple(
+    "Version",
+    [
+        "name",
+        "url",
+        "version",
+        "release",
+        "is_released",
+    ],
+)
+
+
+class VersionInfo:
+    def __init__(self, app, context, metadata, current_version_name):
+        self.app = app
+        self.context = context
+        self.metadata = metadata
+        self.current_version_name = current_version_name
+
+    def _dict_to_versionobj(self, v):
+        return Version(
+            name=v["name"],
+            url=self.vpathto(v["name"]),
+            version=v["version"],
+            release=v["release"],
+            is_released=v["is_released"],
+        )
+
+    @property
+    def tags(self):
+        return [self._dict_to_versionobj(v) for v in self.metadata.values() if v["source"] == "tags"]
+
+    @property
+    def branches(self):
+        return [self._dict_to_versionobj(v) for v in self.metadata.values() if v["source"] != "tags"]
+
+    @property
+    def releases(self):
+        return [self._dict_to_versionobj(v) for v in self.metadata.values() if v["is_released"]]
+
+    @property
+    def in_development(self):
+        return [self._dict_to_versionobj(v) for v in self.metadata.values() if not v["is_released"]]
+
+    def __iter__(self):
+        for item in self.tags:
+            yield item
+        for item in self.branches:
+            yield item
+
+    def __getitem__(self, name):
+        v = self.metadata.get(name)
+        if v:
+            return self._dict_to_versionobj(v)
+
+    def vhasdoc(self, other_version_name):
+        if self.current_version_name == other_version_name:
+            return True
+
+        other_version = self.metadata[other_version_name]
+        return self.context["pagename"] in other_version["docnames"]
+
+    def vpathto(self, other_version_name):
+        if self.current_version_name == other_version_name:
+            return "{}.html".format(posixpath.split(self.context["pagename"])[-1])
+
+        # Find relative outputdir paths from common output root
+        current_version = self.metadata[self.current_version_name]
+        other_version = self.metadata[other_version_name]
+
+        current_outputroot = os.path.abspath(current_version["outputdir"])
+        other_outputroot = os.path.abspath(other_version["outputdir"])
+        outputroot = os.path.commonpath((current_outputroot, other_outputroot))
+
+        current_outputroot = os.path.relpath(current_outputroot, start=outputroot)
+        other_outputroot = os.path.relpath(other_outputroot, start=outputroot)
+
+        # Ensure that we use POSIX separators in the path (for the HTML code)
+        if os.sep != posixpath.sep:
+            current_outputroot = posixpath.join(*os.path.split(current_outputroot))
+            other_outputroot = posixpath.join(*os.path.split(other_outputroot))
+
+        # Find relative path to root of other_version's outputdir
+        current_outputdir = posixpath.dirname(posixpath.join(current_outputroot, self.context["pagename"]))
+        other_outputdir = posixpath.relpath(other_outputroot, start=current_outputdir)
+
+        if not self.vhasdoc(other_version_name):
+            return posixpath.join(other_outputdir, "index.html")
+
+        return posixpath.join(other_outputdir, "{}.html".format(self.context["pagename"]))
+
+
+def html_page_context(app, pagename, templatename, context, doctree):
+    versioninfo = VersionInfo(app, context, app.config.smv_metadata, app.config.smv_current_version)
+    context["versions"] = versioninfo
+    context["vhasdoc"] = versioninfo.vhasdoc
+    context["vpathto"] = versioninfo.vpathto
+
+    context["current_version"] = versioninfo[app.config.smv_current_version]
+    context["latest_version"] = versioninfo[app.config.smv_latest_version]
+    context["html_theme"] = app.config.html_theme
+
+
+def config_inited(app, config):
+    """Update the Sphinx builder.
+    :param sphinx.application.Sphinx app: Sphinx application object.
+    """
+
+    if not config.smv_metadata:
+        if not config.smv_metadata_path:
+            return
+
+        with open(config.smv_metadata_path, mode="r") as f:
+            metadata = json.load(f)
+
+        config.smv_metadata = metadata
+
+    if not config.smv_current_version:
+        return
+
+    try:
+        data = app.config.smv_metadata[config.smv_current_version]
+    except KeyError:
+        return
+
+    app.connect("html-page-context", html_page_context)
+
+    # Restore config values
+    old_config = sphinx_config.Config.read(data["confdir"])
+    old_config.pre_init_values()
+    old_config.init_values()
+    config.version = data["version"]
+    config.release = data["release"]
+    config.rst_prolog = data["rst_prolog"]
+    config.today = old_config.today
+    if not config.today:
+        config.today = sphinx_i18n.format_date(
+            format=config.today_fmt or _("%b %d, %Y"),
+            date=datetime.datetime.strptime(data["creatordate"], DATE_FMT),
+            language=config.language,
+        )
+
+
+def setup(app):
+    app.add_config_value("smv_metadata", {}, "html")
+    app.add_config_value("smv_metadata_path", "", "html")
+    app.add_config_value("smv_current_version", "", "html")
+    app.add_config_value("smv_latest_version", "master", "html")
+    app.add_config_value("smv_tag_whitelist", DEFAULT_TAG_WHITELIST, "html")
+    app.add_config_value("smv_branch_whitelist", DEFAULT_BRANCH_WHITELIST, "html")
+    app.add_config_value("smv_remote_whitelist", DEFAULT_REMOTE_WHITELIST, "html")
+    app.add_config_value("smv_released_pattern", DEFAULT_RELEASED_PATTERN, "html")
+    app.add_config_value("smv_outputdir_format", DEFAULT_OUTPUTDIR_FORMAT, "html")
+    app.connect("config-inited", config_inited)
+
+    return {
+        "version": "0.2",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/poetry.lock
+++ b/poetry.lock
@@ -1563,13 +1563,13 @@ extended-testing = ["aiosqlite (>=0.19.0,<0.20.0)", "aleph-alpha-client (>=2.15.
 
 [[package]]
 name = "langchain-core"
-version = "0.1.27"
+version = "0.1.28"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = ">=3.8.1,<4.0"
 files = [
-    {file = "langchain_core-0.1.27-py3-none-any.whl", hash = "sha256:68eb89dc4a932baf4fb6b4b75b7119eec9e5405e892d2137e9fe0a1d24a40d0c"},
-    {file = "langchain_core-0.1.27.tar.gz", hash = "sha256:698414223525c0bc130d85a614e1493905d588ab72fe0c9ad3b537b1dc62067f"},
+    {file = "langchain_core-0.1.28-py3-none-any.whl", hash = "sha256:f40ca31257e003eb404e6275345d13a1b3839df147153684bab56bb8d80162c6"},
+    {file = "langchain_core-0.1.28.tar.gz", hash = "sha256:04e761a513200b6e5b5818613821945799c07bc5349087d7692e50823107c9d6"},
 ]
 
 [package.dependencies]
@@ -1603,13 +1603,13 @@ requests = ">=2,<3"
 
 [[package]]
 name = "llama-index-core"
-version = "0.10.14"
+version = "0.10.14.post1"
 description = "Interface between LLMs and your data"
 optional = true
 python-versions = ">=3.8.1,<4.0"
 files = [
-    {file = "llama_index_core-0.10.14-py3-none-any.whl", hash = "sha256:52e99ae101a32b2894477e49a0c4bc93de721a71d598fea61e4d9e8e68a35633"},
-    {file = "llama_index_core-0.10.14.tar.gz", hash = "sha256:db6c66948c51751545a73bb3acecfe401649e05296d8865d71d22bcb5a1e55e7"},
+    {file = "llama_index_core-0.10.14.post1-py3-none-any.whl", hash = "sha256:7b12ebebe023e8f5e50c0fcff4af7a67e4842b2e1ca6a84b09442394d2689de6"},
+    {file = "llama_index_core-0.10.14.post1.tar.gz", hash = "sha256:adb931fced7bff092b26599e7f89952c171bf2994872906b5712ecc8107d4727"},
 ]
 
 [package.dependencies]
@@ -3017,13 +3017,13 @@ pytest = ">=7.0"
 
 [[package]]
 name = "python-dateutil"
-version = "2.8.2"
+version = "2.9.0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+    {file = "python-dateutil-2.9.0.tar.gz", hash = "sha256:78e73e19c63f5b20ffa567001531680d939dc042bf7850431877645523c66709"},
+    {file = "python_dateutil-2.9.0-py2.py3-none-any.whl", hash = "sha256:cbf2f1da5e6083ac2fbfd4da39a25f34312230110440f424a14c7558bb85d82e"},
 ]
 
 [package.dependencies]
@@ -3722,9 +3722,9 @@ sphinx = ">=2.1"
 
 [package.source]
 type = "git"
-url = "https://github.com/samtygier-stfc/sphinx-multiversion.git"
-reference = "prebuild_command"
-resolved_reference = "46e20cc02c84ec449e684c8bad748480e4a01d6c"
+url = "https://github.com/Tomas2D/sphinx-multiversion.git"
+reference = "HEAD"
+resolved_reference = "47327d9b8a31c9474566373dfdd6f713e91a3e9a"
 
 [[package]]
 name = "sphinx-notfound-page"
@@ -4334,13 +4334,13 @@ telegram = ["requests"]
 
 [[package]]
 name = "transformers"
-version = "4.38.1"
+version = "4.38.2"
 description = "State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow"
 optional = true
 python-versions = ">=3.8.0"
 files = [
-    {file = "transformers-4.38.1-py3-none-any.whl", hash = "sha256:a7a9265fb060183e9d975cbbadc4d531b10281589c43f6d07563f86322728973"},
-    {file = "transformers-4.38.1.tar.gz", hash = "sha256:86dc84ccbe36123647e84cbd50fc31618c109a41e6be92514b064ab55bf1304c"},
+    {file = "transformers-4.38.2-py3-none-any.whl", hash = "sha256:c4029cb9f01b3dd335e52f364c52d2b37c65b4c78e02e6a08b1919c5c928573e"},
+    {file = "transformers-4.38.2.tar.gz", hash = "sha256:c5fc7ad682b8a50a48b2a4c05d4ea2de5567adb1bdd00053619dbe5960857dd5"},
 ]
 
 [package.dependencies]
@@ -4891,4 +4891,4 @@ localserver = ["fastapi", "uvicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "cc5a445704c33a83d9d8c6e318bb9f5a6351bbae8b3c04e36d9c2507779cc494"
+content-hash = "722308ac7e5be46274086b35d477bca5b646cea856d3c4f19137a2c0da0365b8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3721,10 +3721,8 @@ develop = false
 sphinx = ">=2.1"
 
 [package.source]
-type = "git"
-url = "https://github.com/Tomas2D/sphinx-multiversion.git"
-reference = "HEAD"
-resolved_reference = "47327d9b8a31c9474566373dfdd6f713e91a3e9a"
+type = "directory"
+url = "external/sphinx_multiversion"
 
 [[package]]
 name = "sphinx-notfound-page"
@@ -4891,4 +4889,4 @@ localserver = ["fastapi", "uvicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "722308ac7e5be46274086b35d477bca5b646cea856d3c4f19137a2c0da0365b8"
+content-hash = "009146205b2ff5dfe3f202f31ddae441c038c83576928ea438e0a074a32da19f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ gitchangelog = "3.0.4"
 pystache = "0.6.5"
 tabulate = "0.9.0"
 m2r = "^0.3.1"
-sphinx-multiversion = { "git" = "https://github.com/Tomas2D/sphinx-multiversion.git" }
+sphinx-multiversion = {path = "external/sphinx_multiversion"}
 sphinx-copybutton = "^0.5.2"
 sphinx-notfound-page = "^1.0.0"
 langchain = "^0.1.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ gitchangelog = "3.0.4"
 pystache = "0.6.5"
 tabulate = "0.9.0"
 m2r = "^0.3.1"
-sphinx-multiversion = { "git" = "https://github.com/samtygier-stfc/sphinx-multiversion.git", branch = "prebuild_command" }
+sphinx-multiversion = { "git" = "https://github.com/Tomas2D/sphinx-multiversion.git" }
 sphinx-copybutton = "^0.5.2"
 sphinx-notfound-page = "^1.0.0"
 langchain = "^0.1.4"


### PR DESCRIPTION
The current `sphinx-multiversion` library is no longer maintained and has severe flaws, which we were trying to tackle with various `hacks`. 

For instance, to retrieve a current version when the text generation is being run, we had to parse `version.json` in the parent directory. However, we recently discovered that this approach does not work when multiple documentation sources share the same tag; we cannot detect the current version.

Because the library is relatively small, I've made it a part of our repository and added necessary things.