### PR TITLE
Update watsonx SDK URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is not the [watsonx.ai](https://www.ibm.com/products/watsonx-ai) Python SDK
 
 *You can start a trial version or request a demo via https://www.ibm.com/products/watsonx-ai.*
 
-*Looking for the [watsonx.ai](https://www.ibm.com/products/watsonx-ai) Python SDK? Check out [watson-machine-learning-sdk](https://ibm.github.io/watson-machine-learning-sdk/foundation_models.html).*
+*Looking for the [watsonx.ai](https://www.ibm.com/products/watsonx-ai) Python SDK? Check out [ibm-watsonx-ai](https://ibm.github.io/watsonx-ai-python-sdk/foundation_models.html).*
 
 *Looking for a NodeJS SDK version? Check out [IBM Generative AI NodeJS SDK](https://github.com/IBM/ibm-generative-ai-node-sdk)*
 


### PR DESCRIPTION
Just a README change.

Ref: #338 